### PR TITLE
feat: peer sync (--peer) + external API (--serve) for ExoCortex mobile

### DIFF
--- a/.claude/skills/exocortex-debug/SKILL.md
+++ b/.claude/skills/exocortex-debug/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: exocortex-debug
+description: Diagnose and fix ExoCortex sync issues, tunnel failures, and event flow problems
+tags: [exocortex, infrastructure, kcp, debug, troubleshooting]
+status: draft
+priority: high
+relatedSkills: [exocortex-peer-setup, exocortex-serve-setup]
+---
+
+# ExoCortex Debug
+
+## When to Use This
+
+Use this skill when:
+
+- **Events aren't flowing**: One node has events the others don't
+- **Tunnel keeps dropping**: SSH tunnels reconnect repeatedly
+- **Mobile app can't connect**: External API isn't responding or auth fails
+- **Stale data**: Dashboard shows old data, sessions aren't updating
+- **Post-setup verification**: Confirming the full stack works end-to-end
+
+You're in the right place if:
+- Something in the ExoCortex stack isn't working and you need to find out what
+- You want a quick health check across all nodes
+- You're debugging after a node restart or network change
+
+## Quick Start: Full Health Check
+
+Run this diagnostic script on the hub instance (EC2-A):
+
+```bash
+#!/bin/bash
+# exocortex-health-check.sh — run on the hub instance
+set -e
+
+echo "=== kcp-memory daemon ==="
+curl -sf http://localhost:7735/health | jq . || echo "FAIL: internal API not responding"
+
+echo ""
+echo "=== External API ==="
+curl -sfk https://localhost:8443/health -H "Authorization: Bearer $KCP_API_KEY" | jq . \
+  || echo "FAIL: external API not responding"
+
+echo ""
+echo "=== Peer sync status ==="
+sqlite3 ~/.kcp/memory.db "
+  SELECT peer_id,
+         last_session_ts,
+         last_event_ts,
+         last_push_session_ts,
+         last_push_event_ts,
+         updated_at
+  FROM peer_cursors;
+" -header -column
+
+echo ""
+echo "=== Event distribution ==="
+sqlite3 ~/.kcp/memory.db "
+  SELECT source_instance, COUNT(*) as events
+  FROM tool_events
+  GROUP BY source_instance
+  ORDER BY events DESC;
+" -header -column
+
+echo ""
+echo "=== Session distribution ==="
+sqlite3 ~/.kcp/memory.db "
+  SELECT source_instance, COUNT(*) as sessions
+  FROM sessions
+  GROUP BY source_instance
+  ORDER BY sessions DESC;
+" -header -column
+
+echo ""
+echo "=== SSH tunnels ==="
+ps aux | grep 'ssh -N -L' | grep -v grep || echo "No active SSH tunnels"
+
+echo ""
+echo "=== Recent sync activity (last 10 events) ==="
+sqlite3 ~/.kcp/memory.db "
+  SELECT timestamp, tool, source_instance, substr(event_hash, 1, 12) as hash
+  FROM tool_events
+  ORDER BY timestamp DESC
+  LIMIT 10;
+" -header -column
+
+echo ""
+echo "=== Duplicate check ==="
+DUPES=$(sqlite3 ~/.kcp/memory.db "
+  SELECT COUNT(*) FROM (
+    SELECT event_hash, COUNT(*) c FROM tool_events
+    WHERE event_hash IS NOT NULL
+    GROUP BY event_hash HAVING c > 1
+  );
+")
+echo "Duplicate events: $DUPES"
+```
+
+## Diagnostic Procedures
+
+### 1. Check if sync is running
+
+```bash
+# Are the sync threads alive?
+# Look for peer sync log entries
+journalctl -u kcp-memory --since "5 minutes ago" | grep -i "peer\|sync\|tunnel"
+
+# Check cursor freshness — if updated_at is stale, sync has stalled
+sqlite3 ~/.kcp/memory.db "
+  SELECT peer_id,
+         updated_at,
+         ROUND((julianday('now') - julianday(updated_at)) * 86400) as seconds_ago
+  FROM peer_cursors;
+" -header -column
+```
+
+**Healthy**: `seconds_ago` should be < 60 (syncs every 30s).
+**Stale**: If > 120, the sync loop has stopped or the tunnel is down.
+
+### 2. Check SSH tunnel health
+
+```bash
+# List active tunnels
+ps aux | grep 'ssh -N -L' | grep -v grep
+
+# Test tunnel manually
+# Find the local port from logs:
+journalctl -u kcp-memory | grep "local port" | tail -1
+
+# Probe through the tunnel
+TUNNEL_PORT=<from-logs>
+curl -sf http://localhost:$TUNNEL_PORT/health | jq .
+```
+
+**If tunnel is dead:**
+```bash
+# Check if SSH can reach the peer at all
+ssh -o ConnectTimeout=5 ec2-user@ec2-b.internal echo "reachable"
+
+# Check SSH config
+ssh -vvv -N -L 0:127.0.0.1:7735 ec2-user@ec2-b.internal 2>&1 | head -50
+```
+
+### 3. Trace an event through the system
+
+Pick a recent event from node A and verify it reached node B:
+
+```bash
+# On EC2-A: find a recent local event
+sqlite3 ~/.kcp/memory.db "
+  SELECT event_hash, timestamp, tool, command
+  FROM tool_events
+  WHERE source_instance = 'local'
+  ORDER BY timestamp DESC
+  LIMIT 1;
+"
+# Note the event_hash
+
+# On EC2-B: check if it arrived
+HASH="<event-hash-from-above>"
+sqlite3 ~/.kcp/memory.db "
+  SELECT event_hash, timestamp, source_instance
+  FROM tool_events
+  WHERE event_hash = '$HASH';
+"
+```
+
+**If missing**: The event hasn't been synced yet. Check:
+1. Is the push cursor on EC2-A past that event's timestamp?
+2. Is the tunnel to EC2-B alive?
+3. Does `/ingest/events` on EC2-B respond?
+
+### 4. Check push path (for laptop behind NAT)
+
+The laptop pushes to the hub. Verify:
+
+```bash
+# On the hub (EC2-A): check if laptop events are arriving
+sqlite3 ~/.kcp/memory.db "
+  SELECT source_instance, COUNT(*), MAX(timestamp) as latest
+  FROM tool_events
+  WHERE source_instance LIKE '%laptop%' OR source_instance NOT IN ('local', '<ec2-b-peer-id>')
+  GROUP BY source_instance;
+" -header -column
+
+# On the hub: check ingest endpoint is registered
+curl -sf http://localhost:7735/ingest/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"sessions":[]}'
+# Should return {"ingested":0,"type":"sessions"}
+```
+
+### 5. Verify transitive sync
+
+Event from laptop should reach EC2-B via the hub:
+
+```bash
+# On laptop: find a recent local event hash
+HASH=$(sqlite3 ~/.kcp/memory.db "
+  SELECT event_hash FROM tool_events
+  WHERE source_instance = 'local'
+  ORDER BY timestamp DESC LIMIT 1;
+")
+
+# On EC2-A (hub): verify it arrived
+sqlite3 ~/.kcp/memory.db "SELECT * FROM tool_events WHERE event_hash = '$HASH';" -header
+
+# On EC2-B: verify it propagated through the hub
+sqlite3 ~/.kcp/memory.db "SELECT * FROM tool_events WHERE event_hash = '$HASH';" -header
+```
+
+### 6. Check external API from mobile perspective
+
+```bash
+# Simulate what the Android app does
+API="https://ec2-a.internal:8443"
+KEY="$KCP_API_KEY"
+
+# 1. Health check
+curl -sfk "$API/health" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
+
+# 2. Search (what the app does on the search screen)
+curl -sfk "$API/search?q=test&limit=5" -H "Authorization: Bearer $KEY" | jq '.count'
+
+# 3. Dispatch (what the app does on the chat screen)
+curl -sfk "$API/dispatch" -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"echo hello world","allowed_tools":["Bash"]}' \
+  --max-time 30 --no-buffer
+
+# 4. Capture (what the app does on the capture screen)
+curl -sfk "$API/capture" -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"note","content":"test capture from debug","tags":["debug"]}' \
+  | jq .
+
+# 5. Verify capture was written
+ls -la ~/.kcp/captures/ | tail -1
+```
+
+## Common Failure Modes
+
+### Tunnel reconnect loop
+
+**Pattern**: Logs show "SSH tunnel exited" → "Reconnecting in 2000ms" → repeat
+
+**Causes**:
+1. SSH key not accepted (check `authorized_keys` on remote)
+2. SSM ProxyCommand failing (check AWS credentials)
+3. Remote kcp-memory not running (check remote :7735)
+
+**Fix**: Test SSH manually first, then restart.
+
+### Split-brain (nodes have different events)
+
+**Pattern**: Nodes A and B have events the other doesn't, even after sync.
+
+**Causes**:
+1. Push cursor ahead of actual push (cursor updated but POST failed)
+2. Tunnel was down during a sync window
+
+**Fix**: Reset cursors to force re-sync:
+```bash
+sqlite3 ~/.kcp/memory.db "
+  UPDATE peer_cursors SET
+    last_session_ts = NULL,
+    last_event_ts = NULL,
+    last_push_session_ts = NULL,
+    last_push_event_ts = NULL
+  WHERE peer_id = '<problematic-peer>';
+"
+# Restart kcp-memory — it will do a full re-sync
+```
+
+### Mobile app shows stale data
+
+**Pattern**: Dashboard counts or session list don't update.
+
+**Causes**:
+1. External API caching (shouldn't be, but check)
+2. Peer sync not running on hub
+3. Hub's own scanner hasn't run (30-min interval)
+
+**Fix**:
+```bash
+# Trigger a scan on the hub
+curl -sf -X POST http://localhost:7735/scan
+
+# Check hub's peer cursors are advancing
+watch -n5 'sqlite3 ~/.kcp/memory.db "SELECT * FROM peer_cursors;" -header -column'
+```
+
+## Reference: Key Files and Ports
+
+| Component | Location | Port |
+|-----------|----------|------|
+| Internal API | localhost | 7735 |
+| External API | 0.0.0.0 | 8443 |
+| Memory DB | `~/.kcp/memory.db` | - |
+| Events JSONL | `~/.kcp/events.jsonl` | - |
+| Captures | `~/.kcp/captures/` | - |
+| SSH tunnels | dynamic local port | varies |
+| Logs | journalctl -u kcp-memory | - |
+
+| SQLite Table | Purpose |
+|-------------|---------|
+| `sessions` | Indexed session transcripts |
+| `tool_events` | Tool-call events with `event_hash` |
+| `agent_sessions` | Subagent transcripts |
+| `peer_cursors` | Pull + push sync cursors per peer |
+| `schema_migrations` | Applied migrations (V1-V6) |
+
+## Related Skills
+
+**Prerequisites:**
+- **exocortex-peer-setup** — How to configure --peer connections
+- **exocortex-serve-setup** — How to configure --serve for mobile
+
+---
+
+**Status:** draft | **Priority:** high
+**Tags:** #exocortex #infrastructure #kcp #debug #troubleshooting
+**Last Updated:** 2026-04-12

--- a/.claude/skills/exocortex-peer-setup/SKILL.md
+++ b/.claude/skills/exocortex-peer-setup/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: exocortex-peer-setup
+description: Configure and test kcp-memory --peer connections between ExoCortex instances
+tags: [exocortex, infrastructure, kcp, sync, ssh]
+status: draft
+priority: high
+relatedSkills: [exocortex-serve-setup, exocortex-debug]
+---
+
+# ExoCortex Peer Setup
+
+## When to Use This
+
+Use this skill when:
+
+- **Setting up peer sync**: Connecting two or more kcp-memory instances for bidirectional event replication
+- **Adding a new node**: Connecting a laptop or new EC2 instance to an existing ExoCortex hub
+- **SSH tunnel issues**: Tunnels won't establish or keep dropping
+- **Testing sync**: Verifying events flow correctly between instances
+
+You're in the right place if:
+- You're deploying kcp-memory with `--peer` for the first time
+- You need to verify SSH connectivity between EC2 instances
+- You want to confirm events are replicating between nodes
+
+## Quick Start
+
+```bash
+# On EC2-A (hub): peer with EC2-B
+kcp-memory daemon --peer ssh://ec2-user@ec2-b.internal
+
+# On EC2-B: peer with EC2-A
+kcp-memory daemon --peer ssh://ec2-user@ec2-a.internal
+
+# Verify sync is working (run on either instance)
+curl -s http://localhost:7735/stats | jq '.peer_sync'
+```
+
+## Overview
+
+The `--peer` flag establishes bidirectional sync between kcp-memory instances.
+Each sync cycle (every 30s) pulls new sessions/events from the remote peer
+and pushes local sessions/events to it. Events carry a `source_instance` tag
+and an `event_hash` for deduplication, enabling transitive sync through a hub.
+
+Key concepts:
+- **Hub-and-spoke topology**: One instance (EC2-A) is the hub, others peer with it
+- **SSH tunnels**: Outbound-only, inherits ~/.ssh/config and SSM ProxyCommand
+- **Transitive sync**: Events flow through the hub preserving original source tags
+- **Append-only**: No conflicts — events deduplicated by SHA-256 hash
+
+Relevant files:
+- `peer/SshTunnel.java` — SSH tunnel lifecycle with auto-reconnect
+- `peer/PeerSyncService.java` — Bidirectional pull + push sync loop
+- `store/PeerCursorStore.java` — Replication cursor tracking
+- `handler/IngestHandler.java` — POST /ingest endpoint for receiving pushes
+
+## Implementation Guide
+
+### Step 1: Verify SSH connectivity
+
+Before configuring `--peer`, confirm SSH works between instances:
+
+```bash
+# From EC2-A, test SSH to EC2-B
+ssh ec2-user@ec2-b.internal echo "SSH OK"
+
+# If using SSM Session Manager, verify ProxyCommand works
+ssh -v ec2-user@ec2-b.internal echo "SSM OK"
+
+# Test the specific tunnel command kcp-memory will use
+ssh -N -L 17735:127.0.0.1:7735 ec2-user@ec2-b.internal &
+curl -s http://localhost:17735/health
+kill %1
+```
+
+### Step 2: Verify kcp-memory is running on both instances
+
+```bash
+# On each instance
+curl -s http://localhost:7735/health | jq .
+# Should return: {"status":"ok","sessions":<count>}
+```
+
+### Step 3: Configure hub-and-spoke topology
+
+For a 3-node setup (laptop + EC2-A hub + EC2-B):
+
+```bash
+# EC2-A (hub) — peers with EC2-B, serves mobile
+kcp-memory daemon \
+  --peer ssh://ec2-user@ec2-b.internal \
+  --serve 0.0.0.0:8443 \
+  --tls-cert /etc/kcp/cert.pem \
+  --tls-key /etc/kcp/key.pem \
+  --api-key "$KCP_API_KEY"
+
+# EC2-B — peers with hub only
+kcp-memory daemon \
+  --peer ssh://ec2-user@ec2-a.internal
+
+# Laptop — peers with hub only (outbound SSH, works behind NAT)
+kcp-memory daemon \
+  --peer ssh://ec2-user@ec2-a.internal
+```
+
+### Step 4: Verify sync is working
+
+```bash
+# Check peer cursor state
+sqlite3 ~/.kcp/memory.db "SELECT * FROM peer_cursors;"
+
+# Check that remote events appear locally
+curl -s http://localhost:7735/search?q=* | jq '.results[] | select(.source_instance != "local")'
+
+# Check event counts by source
+sqlite3 ~/.kcp/memory.db "SELECT source_instance, COUNT(*) FROM tool_events GROUP BY source_instance;"
+sqlite3 ~/.kcp/memory.db "SELECT source_instance, COUNT(*) FROM sessions GROUP BY source_instance;"
+```
+
+### Step 5: Adding a new node later
+
+```bash
+# On the hub (EC2-A), add another --peer flag
+kcp-memory daemon \
+  --peer ssh://ec2-user@ec2-b.internal \
+  --peer ssh://ec2-user@ec2-c.internal \
+  --serve 0.0.0.0:8443 ...
+
+# On the new node (EC2-C)
+kcp-memory daemon --peer ssh://ec2-user@ec2-a.internal
+```
+
+Events from EC2-C flow to the hub, which forwards them to EC2-B (and vice versa)
+via transitive sync.
+
+## Troubleshooting
+
+### Issue 1: SSH tunnel fails to establish
+
+**Symptom:**
+```
+WARNING: Failed to spawn SSH tunnel: Cannot run program "ssh"
+```
+
+**Cause:** SSH binary not found or not in PATH.
+
+**Solution:**
+```bash
+# Verify ssh is available
+which ssh
+ssh -V
+
+# If using a custom SSH path
+export PATH="/usr/bin:$PATH"
+```
+
+### Issue 2: Tunnel drops frequently
+
+**Symptom:** Log shows repeated "SSH tunnel exited" / "Reconnecting" messages.
+
+**Cause:** Network instability or missing SSH keepalive.
+
+**Solution:** The tunnel already uses `ServerAliveInterval=30` and
+`ServerAliveCountMax=3`. If still dropping, check:
+
+```bash
+# Test long-lived SSH connection manually
+ssh -N -o ServerAliveInterval=30 ec2-user@ec2-b.internal
+# Leave running for 10 minutes and observe
+
+# Check if a firewall is killing idle connections
+# If so, reduce the interval:
+# In ~/.ssh/config:
+Host ec2-b.internal
+  ServerAliveInterval=15
+```
+
+### Issue 3: Events not syncing
+
+**Symptom:** `peer_cursors` table is empty or timestamps are stale.
+
+**Cause:** Tunnel is up but remote API isn't responding, or `since` parameter
+isn't working.
+
+**Solution:**
+```bash
+# Check if tunnel is forwarding correctly
+TUNNEL_PORT=$(sqlite3 ~/.kcp/memory.db "SELECT 1;")  # get from logs
+curl -s http://localhost:$TUNNEL_PORT/health
+
+# Manually test the sync endpoints
+curl -s "http://localhost:$TUNNEL_PORT/sessions?limit=5" | jq .
+curl -s "http://localhost:$TUNNEL_PORT/events/search?q=*&limit=5" | jq .
+
+# Check cursor state
+sqlite3 ~/.kcp/memory.db "SELECT * FROM peer_cursors;"
+```
+
+### Issue 4: Duplicate events across nodes
+
+**Symptom:** Same event appears multiple times with different source_instance.
+
+**Cause:** Missing `event_hash` — events inserted before V6 migration.
+
+**Solution:**
+```bash
+# Backfill event hashes for existing events
+sqlite3 ~/.kcp/memory.db "
+  UPDATE tool_events
+  SET event_hash = hex(sha256(timestamp || '|' || tool || '|' || command || '|' || session_id))
+  WHERE event_hash IS NULL;
+"
+
+# Verify no duplicates
+sqlite3 ~/.kcp/memory.db "
+  SELECT event_hash, COUNT(*) c FROM tool_events
+  GROUP BY event_hash HAVING c > 1;
+"
+```
+
+## Best Practices
+
+✅ **Use hub-and-spoke**: One hub with `--serve` sees everything. Spokes only
+need one `--peer` connection.
+
+✅ **Let the laptop initiate outbound**: Laptops behind NAT can push/pull
+through their own SSH tunnel. The hub doesn't need to reach back.
+
+✅ **Use SSM Session Manager**: Avoids opening port 22. Add ProxyCommand to
+`~/.ssh/config` on each instance.
+
+❌ **Don't create full mesh for >3 nodes**: Hub-and-spoke scales linearly.
+Full mesh grows quadratically.
+
+❌ **Don't run --serve on a laptop**: Laptops sleep. Put --serve on an
+always-on EC2 instance.
+
+## Related Skills
+
+**Next Steps:**
+- **exocortex-serve-setup** — Configure the mobile-facing external API
+- **exocortex-debug** — Diagnose sync issues, check event flow, verify health
+
+---
+
+**Status:** draft | **Priority:** high
+**Tags:** #exocortex #infrastructure #kcp #sync #ssh
+**Last Updated:** 2026-04-12

--- a/.claude/skills/exocortex-serve-setup/SKILL.md
+++ b/.claude/skills/exocortex-serve-setup/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: exocortex-serve-setup
+description: Configure and test kcp-memory --serve external API for Android mobile access
+tags: [exocortex, infrastructure, kcp, mobile, tls, api]
+status: draft
+priority: high
+relatedSkills: [exocortex-peer-setup, exocortex-debug]
+---
+
+# ExoCortex Mobile Serve Setup
+
+## When to Use This
+
+Use this skill when:
+
+- **Setting up mobile access**: Configuring `--serve` for the first time on the hub instance
+- **TLS certificate issues**: Self-signed certs, Let's Encrypt, or PKCS12 keystore problems
+- **Testing endpoints**: Verifying dispatch, capture, search, and Synthesis proxy work from outside
+- **Android app connectivity**: The mobile app can't reach or authenticate with the API
+
+You're in the right place if:
+- You need to expose kcp-memory's API externally with TLS and auth
+- You're setting up the Android ExoCortex app for the first time
+- You want to test the API with curl before connecting the mobile app
+
+## Quick Start
+
+```bash
+# Generate a self-signed cert for development
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes \
+  -subj "/CN=exocortex.internal"
+
+# Convert to PKCS12 (what Java TLS expects)
+openssl pkcs12 -export -in cert.pem -inkey key.pem -out keystore.p12 -password pass:changeit
+
+# Start with external API
+export KCP_API_KEY=$(openssl rand -hex 32)
+kcp-memory daemon \
+  --serve 0.0.0.0:8443 \
+  --tls-cert keystore.p12 \
+  --tls-key changeit \
+  --api-key "$KCP_API_KEY"
+
+# Test from another machine
+curl -sk https://ec2-a.internal:8443/health \
+  -H "Authorization: Bearer $KCP_API_KEY"
+```
+
+## Overview
+
+The `--serve` flag starts a second HTTP server (alongside the internal :7735)
+that is TLS-encrypted, API-key-protected, and bound to an external interface.
+This is the single entry point for the Android app and any other external client.
+
+It exposes all internal endpoints (search, sessions, stats, events) plus
+mobile-specific endpoints:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/health` | GET | Liveness check |
+| `/search?q=` | GET | Full-text session search |
+| `/sessions` | GET | List recent sessions (all nodes via peer sync) |
+| `/events/search?q=` | GET | Tool event search |
+| `/stats` | GET | Aggregate statistics |
+| `/dispatch` | POST | Send task to Claude Code, stream results |
+| `/capture` | POST | Ingest voice/photo/note from mobile |
+| `/synthesis/search?q=` | GET | Proxy query to local Synthesis |
+
+All requests require `Authorization: Bearer <api-key>`.
+
+Relevant files:
+- `server/ExternalHttpServer.java` — TLS + API key auth server
+- `handler/DispatchHandler.java` — Claude Code task dispatch
+- `handler/CaptureHandler.java` — Mobile knowledge capture ingest
+- `handler/SynthesisProxyHandler.java` — Synthesis search proxy
+
+## Implementation Guide
+
+### Step 1: TLS Certificate
+
+**Option A: Self-signed (development)**
+```bash
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes \
+  -subj "/CN=$(hostname)"
+openssl pkcs12 -export -in cert.pem -inkey key.pem -out ~/.kcp/keystore.p12 -password pass:changeit
+```
+
+**Option B: Let's Encrypt (production)**
+```bash
+# Using certbot with a domain pointed at your EC2 instance
+sudo certbot certonly --standalone -d exocortex.yourdomain.com
+openssl pkcs12 -export \
+  -in /etc/letsencrypt/live/exocortex.yourdomain.com/fullchain.pem \
+  -inkey /etc/letsencrypt/live/exocortex.yourdomain.com/privkey.pem \
+  -out ~/.kcp/keystore.p12 -password pass:changeit
+```
+
+**Option C: No TLS (behind a reverse proxy)**
+
+If you run nginx/caddy in front, skip TLS on kcp-memory:
+```bash
+# kcp-memory without TLS (proxy handles it)
+kcp-memory daemon --serve 127.0.0.1:8080 --api-key "$KCP_API_KEY"
+```
+
+### Step 2: API Key
+
+```bash
+# Generate a strong key
+export KCP_API_KEY=$(openssl rand -hex 32)
+echo "$KCP_API_KEY" > ~/.kcp/api-key
+chmod 600 ~/.kcp/api-key
+
+# Or set in environment for systemd
+# In /etc/systemd/system/kcp-memory.service:
+# Environment=KCP_API_KEY=<your-key>
+```
+
+### Step 3: Start the external server
+
+```bash
+kcp-memory daemon \
+  --peer ssh://ec2-user@ec2-b.internal \
+  --serve 0.0.0.0:8443 \
+  --tls-cert ~/.kcp/keystore.p12 \
+  --tls-key changeit \
+  --api-key "$KCP_API_KEY" \
+  --capture-dir ~/.kcp/captures \
+  --synthesis-cmd "synthesis search"
+```
+
+### Step 4: Test every endpoint
+
+```bash
+API="https://ec2-a.internal:8443"
+AUTH="Authorization: Bearer $KCP_API_KEY"
+
+# Health
+curl -sk "$API/health" -H "$AUTH" | jq .
+
+# Search sessions
+curl -sk "$API/search?q=lib-pcb&limit=5" -H "$AUTH" | jq .
+
+# List sessions (includes remote via peer sync)
+curl -sk "$API/sessions?limit=10" -H "$AUTH" | jq .
+
+# Search events
+curl -sk "$API/events/search?q=mvn+test&limit=5" -H "$AUTH" | jq .
+
+# Stats
+curl -sk "$API/stats" -H "$AUTH" | jq .
+
+# Dispatch a task (streaming response)
+curl -sk "$API/dispatch" -H "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"What files are in the current directory?","allowed_tools":["Bash","Glob"]}' \
+  --no-buffer
+
+# Capture a note
+curl -sk "$API/capture" -H "$AUTH" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"note","content":"Remember to update the CI pipeline","tags":["ops"]}'
+
+# Synthesis search
+curl -sk "$API/synthesis/search?q=PCBDesign&limit=5" -H "$AUTH" | jq .
+
+# Verify auth is enforced (should return 401)
+curl -sk "$API/health"
+```
+
+### Step 5: AWS Security Group
+
+```bash
+# Allow inbound 8443 from your IP / VPN only
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-xxx \
+  --protocol tcp \
+  --port 8443 \
+  --cidr <your-ip>/32
+```
+
+### Step 6: systemd service
+
+```ini
+# /etc/systemd/system/kcp-memory.service
+[Unit]
+Description=kcp-memory ExoCortex daemon
+After=network.target
+
+[Service]
+Type=simple
+User=ec2-user
+Environment=KCP_API_KEY=<your-key>
+ExecStart=/usr/bin/java --enable-native-access=ALL-UNNAMED \
+  -jar /home/ec2-user/.kcp/kcp-memory-daemon.jar daemon \
+  --peer ssh://ec2-user@ec2-b.internal \
+  --serve 0.0.0.0:8443 \
+  --tls-cert /home/ec2-user/.kcp/keystore.p12 \
+  --tls-key changeit \
+  --capture-dir /home/ec2-user/.kcp/captures \
+  --synthesis-cmd "synthesis search"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable kcp-memory
+sudo systemctl start kcp-memory
+sudo journalctl -u kcp-memory -f
+```
+
+## Troubleshooting
+
+### Issue 1: "Unauthorized" from mobile app
+
+**Symptom:** All requests return `{"error":"Unauthorized"}`
+
+**Solution:**
+```bash
+# Verify the API key matches
+echo $KCP_API_KEY
+# Compare with what the app is sending
+
+# Test with explicit header
+curl -sk https://host:8443/health -H "Authorization: Bearer YOUR_KEY"
+```
+
+### Issue 2: TLS handshake failure
+
+**Symptom:** `javax.net.ssl.SSLHandshakeException` or `curl: SSL certificate problem`
+
+**Solution:**
+```bash
+# Verify the keystore is valid
+keytool -list -keystore ~/.kcp/keystore.p12 -storetype PKCS12 -storepass changeit
+
+# Test TLS with openssl
+openssl s_client -connect localhost:8443 -servername localhost
+
+# For self-signed certs, use -k with curl (or install the CA on Android)
+curl -sk https://host:8443/health -H "Authorization: Bearer $KEY"
+```
+
+### Issue 3: Dispatch hangs or returns empty
+
+**Symptom:** POST /dispatch returns no output or times out.
+
+**Solution:**
+```bash
+# Verify claude is installed and on PATH
+which claude
+claude --version
+
+# Test claude -p directly
+claude -p "echo hello" --output-format stream-json --allowedTools "Bash"
+
+# Check the working directory exists
+ls -la /home/ec2-user/projects/lib-pcb
+```
+
+### Issue 4: Capture files not being indexed by Synthesis
+
+**Symptom:** Notes captured via mobile don't appear in Synthesis search.
+
+**Solution:**
+```bash
+# Check captures directory
+ls -la ~/.kcp/captures/
+
+# Verify Synthesis watches this directory
+synthesis status
+
+# Trigger a manual Synthesis scan
+synthesis scan ~/.kcp/captures/
+```
+
+## Best Practices
+
+✅ **Use Let's Encrypt for production**: Self-signed certs require
+installing the CA on every Android device.
+
+✅ **Restrict Security Group**: Only allow :8443 from your IP or VPN CIDR.
+
+✅ **Rotate the API key periodically**: Generate a new one, update the
+Android app, restart the daemon.
+
+✅ **Run behind a reverse proxy**: Caddy with automatic HTTPS is simpler
+than managing PKCS12 keystores.
+
+❌ **Don't expose without TLS**: Even with an API key, traffic would be
+readable in transit.
+
+❌ **Don't use --serve on port 7735**: That's the internal API. Keep them
+on separate ports.
+
+## Related Skills
+
+**Prerequisites:**
+- **exocortex-peer-setup** — Set up peer sync before enabling mobile access
+
+**Next Steps:**
+- **exocortex-debug** — Diagnose issues with the full ExoCortex stack
+
+---
+
+**Status:** draft | **Priority:** high
+**Tags:** #exocortex #infrastructure #kcp #mobile #tls #api
+**Last Updated:** 2026-04-12

--- a/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
+++ b/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
@@ -2,14 +2,19 @@ package com.cantara.kcp.memory;
 
 import com.cantara.kcp.memory.handler.*;
 import com.cantara.kcp.memory.mcp.McpServer;
+import com.cantara.kcp.memory.peer.PeerSyncService;
 import com.cantara.kcp.memory.scanner.AgentSessionScanner;
 import com.cantara.kcp.memory.scanner.EventLogScanner;
 import com.cantara.kcp.memory.scanner.SessionScanner;
+import com.cantara.kcp.memory.server.ExternalHttpServer;
 import com.cantara.kcp.memory.server.TcpHttpServer;
 import com.cantara.kcp.memory.store.MemoryDatabase;
 import com.cantara.kcp.memory.update.UpdateChecker;
 
+import java.nio.file.Path;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +45,8 @@ public class KcpMemoryDaemon {
     private final MemoryDatabase db;
     private TcpHttpServer server;
     private ScheduledExecutorService scheduler;
+    private final List<PeerSyncService> peerSyncServices = new ArrayList<>();
+    private ExternalHttpServer externalServer;
 
     public KcpMemoryDaemon(MemoryDatabase db) {
         this.db = db;
@@ -54,6 +61,7 @@ public class KcpMemoryDaemon {
         server.createContext("/stats",         new StatsHandler(db));
         server.createContext("/scan",          new ScanHandler(db));
         server.createContext("/events/search", new EventsHandler(db));
+        server.createContext("/ingest",        new IngestHandler(db));
 
         server.start();
         LOG.info("kcp-memory daemon started on port " + PORT);
@@ -100,13 +108,54 @@ public class KcpMemoryDaemon {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             LOG.info("Shutting down kcp-memory daemon...");
             scheduler.shutdownNow();
+            peerSyncServices.forEach(PeerSyncService::stop);
+            if (externalServer != null) externalServer.stop();
             server.stop();
             try { db.close(); } catch (SQLException ignored) {}
         }));
     }
 
+    /**
+     * Start bidirectional peer sync. Call after start(). Repeatable.
+     * @param peerUri ssh://user@host or tcp://host:port
+     * @param localInstanceId this instance's identifier (hostname)
+     */
+    public void startPeerSync(String peerUri, String localInstanceId) {
+        PeerSyncService sync = new PeerSyncService(db, peerUri, localInstanceId);
+        sync.start();
+        peerSyncServices.add(sync);
+    }
+
+    /**
+     * Start the external API server for mobile access. Call after start().
+     */
+    public void startExternalServer(String bindAddress, int port,
+                                     String tlsCert, String tlsKey,
+                                     String apiKey, String captureDir,
+                                     String synthesisCmd) throws Exception {
+        externalServer = new ExternalHttpServer(bindAddress, port, tlsCert, tlsKey, apiKey);
+
+        // Register all internal endpoints (same data, external auth)
+        externalServer.createContext("/health", new HealthHandler(db));
+        externalServer.createContext("/search", new SearchHandler(db));
+        externalServer.createContext("/sessions", new ListHandler(db));
+        externalServer.createContext("/stats", new StatsHandler(db));
+        externalServer.createContext("/events/search", new EventsHandler(db));
+
+        // Mobile-specific endpoints
+        externalServer.createContext("/dispatch", new DispatchHandler());
+        externalServer.createContext("/capture",
+                new CaptureHandler(Path.of(captureDir != null ? captureDir : System.getProperty("user.home") + "/.kcp/captures")));
+        externalServer.createContext("/synthesis/search",
+                new SynthesisProxyHandler(synthesisCmd != null ? synthesisCmd : "synthesis search"));
+
+        externalServer.start();
+    }
+
     public void stop() {
         if (scheduler != null) scheduler.shutdownNow();
+        peerSyncServices.forEach(PeerSyncService::stop);
+        if (externalServer != null) externalServer.stop();
         if (server    != null) server.stop();
     }
 }

--- a/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
+++ b/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
@@ -63,6 +63,37 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "daemon", description = "Start the kcp-memory HTTP daemon on port 7735")
     static class DaemonCmd implements Callable<Integer> {
 
+        @Option(names = "--peer", arity = "0..*",
+                description = "Peer URI(s) for bidirectional sync (repeatable: ssh://user@host or tcp://host:port)")
+        private List<String> peerUris;
+
+        @Option(names = "--serve",
+                description = "Bind address for external mobile API (e.g., 0.0.0.0:8443)")
+        private String serveAddress;
+
+        @Option(names = "--tls-cert",
+                description = "Path to TLS certificate (PEM or PKCS12)")
+        private String tlsCert;
+
+        @Option(names = "--tls-key",
+                description = "Path to TLS private key (PEM or password)")
+        private String tlsKey;
+
+        @Option(names = "--api-key",
+                description = "API key for external access (or KCP_API_KEY env)",
+                defaultValue = "${KCP_API_KEY}")
+        private String apiKey;
+
+        @Option(names = "--capture-dir",
+                description = "Directory for mobile knowledge captures",
+                defaultValue = "~/.kcp/captures")
+        private String captureDir;
+
+        @Option(names = "--synthesis-cmd",
+                description = "Command to query Synthesis",
+                defaultValue = "synthesis search")
+        private String synthesisCmd;
+
         @Override
         public Integer call() throws Exception {
             MemoryDatabase db = new MemoryDatabase();
@@ -70,6 +101,33 @@ public class KcpMemoryCli implements Callable<Integer> {
             daemon.start();
             System.out.printf("[kcp-memory] daemon running on port %d — press Ctrl+C to stop%n",
                     KcpMemoryDaemon.PORT);
+
+            // Start peer sync if --peer specified
+            String localId = java.net.InetAddress.getLocalHost().getHostName();
+            if (peerUris != null) {
+                for (String uri : peerUris) {
+                    System.out.printf("[kcp-memory] starting peer sync with %s%n", uri);
+                    daemon.startPeerSync(uri, localId);
+                }
+            }
+
+            // Start external server if --serve specified
+            if (serveAddress != null) {
+                if (apiKey == null || apiKey.isBlank() || apiKey.equals("${KCP_API_KEY}")) {
+                    System.err.println("ERROR: --api-key (or KCP_API_KEY env) required with --serve");
+                    return 1;
+                }
+                String[] parts = serveAddress.split(":");
+                String host = parts.length > 1 ? parts[0] : "0.0.0.0";
+                int port = Integer.parseInt(parts[parts.length - 1]);
+
+                // Expand ~ in capture-dir
+                String expandedCaptureDir = captureDir.replace("~", System.getProperty("user.home"));
+
+                daemon.startExternalServer(host, port, tlsCert, tlsKey, apiKey, expandedCaptureDir, synthesisCmd);
+                System.out.printf("[kcp-memory] external API serving on %s:%d%n", host, port);
+            }
+
             Thread.currentThread().join(); // block until killed
             return 0;
         }

--- a/java/src/main/java/com/cantara/kcp/memory/handler/CaptureHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/CaptureHandler.java
@@ -1,0 +1,99 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * POST /capture — ingest knowledge captures from mobile.
+ *
+ * <p>Accepts JSON body with:
+ * <pre>
+ * {
+ *   "type": "note",         // "note", "voice_transcript", "photo_ocr"
+ *   "content": "...",       // text content
+ *   "tags": ["lib-pcb"],   // optional tags
+ *   "title": "..."         // optional title
+ * }
+ * </pre>
+ *
+ * <p>Writes a markdown file to the capture directory. Synthesis picks it up
+ * on its next indexing pass.
+ */
+public class CaptureHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(CaptureHandler.class.getName());
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final DateTimeFormatter TS_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss").withZone(ZoneOffset.UTC);
+
+    private final Path captureDir;
+
+    public CaptureHandler(Path captureDir) {
+        this.captureDir = captureDir;
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        var body = JSON.readTree(ex.getRequestBody());
+
+        String type = body.path("type").asText("note");
+        String content = body.path("content").asText(null);
+        String title = body.path("title").asText(null);
+
+        if (content == null || content.isBlank()) {
+            sendError(ex, 400, "Missing required field: content");
+            return;
+        }
+
+        // Build tags
+        StringBuilder tags = new StringBuilder();
+        var tagsNode = body.get("tags");
+        if (tagsNode != null && tagsNode.isArray()) {
+            for (var tag : tagsNode) {
+                if (!tags.isEmpty()) tags.append(", ");
+                tags.append(tag.asText());
+            }
+        }
+
+        // Generate filename: capture-2026-04-12T14-30-00-note.md
+        String timestamp = TS_FORMAT.format(Instant.now());
+        String filename = "capture-" + timestamp + "-" + type + ".md";
+        Path filePath = captureDir.resolve(filename);
+
+        // Write as markdown with frontmatter (Synthesis-friendly)
+        StringBuilder md = new StringBuilder();
+        md.append("---\n");
+        md.append("type: ").append(type).append("\n");
+        md.append("captured: ").append(Instant.now().toString()).append("\n");
+        md.append("source: mobile\n");
+        if (!tags.isEmpty()) md.append("tags: [").append(tags).append("]\n");
+        md.append("---\n\n");
+        if (title != null) md.append("# ").append(title).append("\n\n");
+        md.append(content).append("\n");
+
+        // Ensure directory exists and write
+        Files.createDirectories(captureDir);
+        Files.writeString(filePath, md.toString());
+
+        LOG.info("Captured " + type + ": " + filename);
+        sendJson(ex, 201, Map.of(
+                "status", "captured",
+                "file", filename,
+                "path", filePath.toString()
+        ));
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/handler/DispatchHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/DispatchHandler.java
@@ -1,0 +1,122 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * POST /dispatch — send a task to Claude Code and stream the results.
+ *
+ * <p>Request body:
+ * <pre>
+ * {
+ *   "prompt": "Run the test suite for lib-pcb",
+ *   "allowed_tools": ["Bash", "Read", "Glob", "Grep"],
+ *   "working_dir": "/home/ec2-user/projects/lib-pcb"
+ * }
+ * </pre>
+ *
+ * <p>Response: streams {@code claude -p --output-format stream-json} output
+ * line-by-line as chunked transfer encoding. This lets the mobile client
+ * show progress in real time.
+ */
+public class DispatchHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(DispatchHandler.class.getName());
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        // Parse request body
+        JsonNode body;
+        try {
+            body = JSON.readTree(ex.getRequestBody());
+        } catch (Exception e) {
+            sendError(ex, 400, "Invalid JSON body");
+            return;
+        }
+
+        String prompt = body.path("prompt").asText(null);
+        if (prompt == null || prompt.isBlank()) {
+            sendError(ex, 400, "Missing required field: prompt");
+            return;
+        }
+
+        String workingDir = body.path("working_dir").asText(System.getProperty("user.home"));
+
+        // Build allowed tools list
+        List<String> allowedTools = new ArrayList<>();
+        JsonNode toolsNode = body.get("allowed_tools");
+        if (toolsNode != null && toolsNode.isArray()) {
+            for (JsonNode tool : toolsNode) {
+                allowedTools.add(tool.asText());
+            }
+        }
+        if (allowedTools.isEmpty()) {
+            allowedTools = List.of("Read", "Glob", "Grep");  // safe default: read-only
+        }
+
+        // Build claude command
+        List<String> cmd = new ArrayList<>();
+        cmd.add("claude");
+        cmd.add("-p");
+        cmd.add(prompt);
+        cmd.add("--output-format");
+        cmd.add("stream-json");
+        cmd.add("--verbose");
+        cmd.add("--allowedTools");
+        cmd.add(String.join(",", allowedTools));
+
+        LOG.info("Dispatching task: " + prompt.substring(0, Math.min(prompt.length(), 80)));
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.directory(new java.io.File(workingDir));
+            pb.redirectErrorStream(true);
+
+            Process process = pb.start();
+
+            // Stream output line by line
+            ex.sendStreamingHeaders(200, "application/x-ndjson; charset=utf-8");
+            OutputStream out = ex.getOutputStream();
+
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    out.write(line.getBytes(StandardCharsets.UTF_8));
+                    out.write('\n');
+                    out.flush();
+                }
+            }
+
+            int exitCode = process.waitFor();
+            // Send a final status line
+            String status = "{\"type\":\"dispatch_complete\",\"exit_code\":" + exitCode + "}\n";
+            out.write(status.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            LOG.info("Dispatch completed with exit code " + exitCode);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            sendError(ex, 500, "Task interrupted");
+        } catch (Exception e) {
+            LOG.warning("Dispatch failed: " + e.getMessage());
+            sendError(ex, 500, "Dispatch failed: " + e.getMessage());
+        }
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
@@ -1,0 +1,150 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.peer.PeerSyncService;
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * POST /ingest/sessions and POST /ingest/events — accept data pushed from peers.
+ *
+ * <p>This is the counterpart to PeerSyncService's push phase. It runs on the
+ * internal API (localhost:7735) only, never on the external mobile API.
+ *
+ * <p>Handles both session and event ingestion based on path:
+ * <ul>
+ *   <li>{@code /ingest/sessions} — accepts a JSON array of sessions</li>
+ *   <li>{@code /ingest/events} — accepts a JSON array of tool events</li>
+ * </ul>
+ *
+ * <p>All records use INSERT OR IGNORE — duplicates are silently skipped.
+ * Events use {@code event_hash} for deduplication across any sync path.
+ */
+public class IngestHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(IngestHandler.class.getName());
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final MemoryDatabase db;
+
+    public IngestHandler(MemoryDatabase db) {
+        this.db = db;
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        String path = ex.getRequestURI().getPath();
+        JsonNode body;
+        try {
+            body = JSON.readTree(ex.getRequestBody());
+        } catch (Exception e) {
+            sendError(ex, 400, "Invalid JSON");
+            return;
+        }
+
+        try {
+            if (path.endsWith("/sessions")) {
+                int count = ingestSessions(body);
+                sendJson(ex, 200, Map.of("ingested", count, "type", "sessions"));
+            } else if (path.endsWith("/events")) {
+                int count = ingestEvents(body);
+                sendJson(ex, 200, Map.of("ingested", count, "type", "events"));
+            } else {
+                sendError(ex, 404, "Use /ingest/sessions or /ingest/events");
+            }
+        } catch (SQLException e) {
+            LOG.warning("Ingest failed: " + e.getMessage());
+            sendError(ex, 500, "Ingest failed: " + e.getMessage());
+        }
+    }
+
+    private int ingestSessions(JsonNode body) throws SQLException {
+        JsonNode sessions = body.get("sessions");
+        if (sessions == null || !sessions.isArray()) return 0;
+
+        int count = 0;
+        for (JsonNode session : sessions) {
+            String sessionId = session.path("session_id").asText(null);
+            String projectDir = session.path("project_dir").asText("");
+            String firstMessage = session.path("first_message").asText("");
+            String startedAt = session.path("started_at").asText(null);
+            String source = session.path("source_instance").asText("unknown");
+            int turnCount = session.path("turn_count").asInt(0);
+            int toolCallCount = session.path("tool_call_count").asInt(0);
+
+            if (sessionId == null || startedAt == null) continue;
+
+            try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                    INSERT OR IGNORE INTO sessions
+                        (session_id, project_dir, first_message, started_at,
+                         turn_count, tool_call_count, scanned_at, source_instance)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+                    """)) {
+                ps.setString(1, sessionId);
+                ps.setString(2, projectDir);
+                ps.setString(3, firstMessage);
+                ps.setString(4, startedAt);
+                ps.setInt(5, turnCount);
+                ps.setInt(6, toolCallCount);
+                ps.setString(7, source);
+                count += ps.executeUpdate();
+            }
+        }
+        LOG.fine("Ingested " + count + " sessions from peer push");
+        return count;
+    }
+
+    private int ingestEvents(JsonNode body) throws SQLException {
+        JsonNode events = body.get("events");
+        if (events == null || !events.isArray()) return 0;
+
+        int count = 0;
+        for (JsonNode event : events) {
+            String eventTs = event.path("event_ts").asText(null);
+            String tool = event.path("tool").asText("Bash");
+            String command = event.path("command").asText("");
+            String sessionId = event.path("session_id").asText("");
+            String projectDir = event.path("project_dir").asText("");
+            String outputPreview = event.path("output_preview").asText(null);
+            String source = event.path("source_instance").asText("unknown");
+
+            String hash = event.path("event_hash").asText(null);
+            if (hash == null) {
+                hash = PeerSyncService.computeEventHash(eventTs, tool, command, sessionId);
+            }
+
+            if (eventTs == null) continue;
+
+            try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                    INSERT OR IGNORE INTO tool_events
+                        (event_ts, session_id, project_dir, tool, command,
+                         output_preview, ingested_at, source_instance, event_hash)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?, ?)
+                    """)) {
+                ps.setString(1, eventTs);
+                ps.setString(2, sessionId);
+                ps.setString(3, projectDir);
+                ps.setString(4, tool);
+                ps.setString(5, command);
+                ps.setString(6, outputPreview);
+                ps.setString(7, source);
+                ps.setString(8, hash);
+                count += ps.executeUpdate();
+            }
+        }
+        LOG.fine("Ingested " + count + " events from peer push");
+        return count;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/handler/SynthesisProxyHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/SynthesisProxyHandler.java
@@ -1,0 +1,99 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * GET /synthesis/search?q=&lt;query&gt; — proxy search queries to local Synthesis instance.
+ *
+ * <p>Shells out to the configured Synthesis CLI command (default: {@code synthesis search}).
+ * Returns the raw Synthesis output as JSON.
+ */
+public class SynthesisProxyHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(SynthesisProxyHandler.class.getName());
+
+    private final String synthesisCommand;
+
+    /**
+     * @param synthesisCommand the CLI command to invoke, e.g. "synthesis search"
+     */
+    public SynthesisProxyHandler(String synthesisCommand) {
+        this.synthesisCommand = synthesisCommand;
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"GET".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        Map<String, String> params = queryParams(ex);
+        String query = params.get("q");
+        if (query == null || query.isBlank()) {
+            sendError(ex, 400, "Missing required parameter: q");
+            return;
+        }
+
+        int limit = 20;
+        try {
+            limit = Integer.parseInt(params.getOrDefault("limit", "20"));
+        } catch (NumberFormatException ignored) {
+        }
+
+        try {
+            // Build command: synthesis search "query" --limit 20 --json
+            ProcessBuilder pb = new ProcessBuilder(
+                    "sh", "-c",
+                    synthesisCommand + " \"" + escapeShell(query) + "\" --limit " + limit + " --json"
+            );
+            pb.redirectErrorStream(true);
+
+            Process process = pb.start();
+
+            StringBuilder output = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append('\n');
+                }
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                sendError(ex, 502, "Synthesis exited with code " + exitCode + ": " + output);
+                return;
+            }
+
+            // Return Synthesis output directly as JSON
+            String json = output.toString().trim();
+            if (json.startsWith("{") || json.startsWith("[")) {
+                ex.sendResponse(200, "application/json; charset=utf-8",
+                        json.getBytes(StandardCharsets.UTF_8));
+            } else {
+                // Wrap plain text in JSON
+                sendJson(ex, 200, Map.of("query", query, "raw_output", json));
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            sendError(ex, 500, "Synthesis query interrupted");
+        } catch (Exception e) {
+            LOG.warning("Synthesis proxy failed: " + e.getMessage());
+            sendError(ex, 500, "Synthesis query failed: " + e.getMessage());
+        }
+    }
+
+    /** Basic shell escaping — replace single quotes. */
+    private static String escapeShell(String input) {
+        return input.replace("'", "'\\''").replace("\"", "\\\"");
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
@@ -1,0 +1,405 @@
+package com.cantara.kcp.memory.peer;
+
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.cantara.kcp.memory.store.PeerCursorStore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Bidirectional sync service between kcp-memory instances.
+ *
+ * <p>Each sync cycle does two things:
+ * <ol>
+ *   <li><b>Pull</b> — fetch new sessions/events from the remote peer's HTTP API</li>
+ *   <li><b>Push</b> — POST local sessions/events to the remote peer's {@code /ingest} endpoint</li>
+ * </ol>
+ *
+ * <p>This enables hub-and-spoke topology: a laptop behind NAT initiates an outbound
+ * SSH tunnel and both pulls and pushes through it. The hub (EC2-A) never needs
+ * to reach the laptop directly.
+ *
+ * <p><b>Transitive sync:</b> events received from one peer carry their original
+ * {@code source_instance} tag. When served to another peer, they flow through
+ * unchanged. The {@code event_hash} unique index prevents duplicates regardless
+ * of which path an event arrives through.
+ *
+ * <p>Supports two transport modes:
+ * <ul>
+ *   <li>{@code ssh://user@host} — managed SSH tunnel (via {@link SshTunnel})</li>
+ *   <li>{@code tcp://host:port} — direct TCP (trusted network)</li>
+ * </ul>
+ */
+public class PeerSyncService {
+
+    private static final Logger LOG = Logger.getLogger(PeerSyncService.class.getName());
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static final int SYNC_INTERVAL_SECONDS = 30;
+
+    private final MemoryDatabase db;
+    private final PeerCursorStore cursorStore;
+    private final String peerUri;
+    private final String localInstanceId;
+
+    private SshTunnel tunnel;
+    private String baseUrl;
+    private String peerId;
+    private HttpClient httpClient;
+    private ScheduledExecutorService scheduler;
+
+    /**
+     * @param db              local database
+     * @param peerUri         ssh://user@host or tcp://host:port
+     * @param localInstanceId identifier for this instance (e.g., hostname)
+     */
+    public PeerSyncService(MemoryDatabase db, String peerUri, String localInstanceId) {
+        this.db = db;
+        this.cursorStore = new PeerCursorStore(db);
+        this.peerUri = peerUri;
+        this.localInstanceId = localInstanceId;
+    }
+
+    /** Start the sync service. Establishes tunnel if SSH, then starts polling. */
+    public void start() {
+        httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        if (peerUri.startsWith("ssh://")) {
+            tunnel = SshTunnel.fromUri(peerUri);
+            tunnel.start();
+            baseUrl = "http://127.0.0.1:" + tunnel.getLocalPort();
+            peerId = tunnel.getPeerId();
+            LOG.info("Peer sync via SSH tunnel: " + peerId + " -> " + baseUrl);
+        } else if (peerUri.startsWith("tcp://")) {
+            String hostPort = peerUri.substring("tcp://".length());
+            baseUrl = "http://" + hostPort;
+            peerId = hostPort;
+            LOG.info("Peer sync via direct TCP: " + baseUrl);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported peer URI scheme. Use ssh://user@host or tcp://host:port");
+        }
+
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "kcp-peer-sync-" + peerId);
+            t.setDaemon(true);
+            return t;
+        });
+
+        // Initial sync after 5s (let tunnel establish), then every 30s
+        scheduler.scheduleAtFixedRate(this::syncOnce, 5, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        LOG.info("Peer sync scheduled every " + SYNC_INTERVAL_SECONDS + "s with " + peerId);
+    }
+
+    /** Stop the sync service and close the tunnel. */
+    public void stop() {
+        if (scheduler != null) scheduler.shutdownNow();
+        if (tunnel != null) tunnel.stop();
+        LOG.info("Peer sync stopped for " + peerId);
+    }
+
+    public boolean isConnected() {
+        return tunnel == null || tunnel.isConnected();
+    }
+
+    public String getPeerId() {
+        return peerId;
+    }
+
+    // --- sync cycle ---
+
+    private void syncOnce() {
+        try {
+            pullSessions();
+            pullEvents();
+            pushSessions();
+            pushEvents();
+        } catch (Exception e) {
+            LOG.warning("Peer sync failed for " + peerId + ": " + e.getMessage());
+        }
+    }
+
+    // --- PULL: fetch from remote, merge locally ---
+
+    private void pullSessions() throws IOException, InterruptedException, SQLException {
+        String since = cursorStore.getLastSessionTs(peerId);
+        String url = baseUrl + "/sessions?limit=100"
+                + (since != null ? "&since=" + since : "");
+
+        JsonNode response = fetchJson(url);
+        if (response == null) return;
+
+        JsonNode sessions = response.get("sessions");
+        if (sessions == null || !sessions.isArray() || sessions.isEmpty()) return;
+
+        String latestTs = null;
+        int count = 0;
+
+        for (JsonNode session : sessions) {
+            // Jackson serializes SearchResult as camelCase (getSessionId -> sessionId)
+            String sessionId = session.path("sessionId").asText(
+                    session.path("session_id").asText(null));
+            String startedAt = session.path("startedAt").asText(
+                    session.path("started_at").asText(null));
+            String projectDir = session.path("projectDir").asText(
+                    session.path("project_dir").asText(""));
+            String firstMessage = session.path("firstMessage").asText(
+                    session.path("first_message").asText(""));
+            int turnCount = session.has("turnCount") ? session.path("turnCount").asInt(0)
+                    : session.path("turn_count").asInt(0);
+            int toolCallCount = session.has("toolCallCount") ? session.path("toolCallCount").asInt(0)
+                    : session.path("tool_call_count").asInt(0);
+            // Preserve original source — enables transitive sync
+            String source = session.path("source_instance").asText(peerId);
+            if ("local".equals(source)) source = peerId;
+
+            if (sessionId == null || startedAt == null) continue;
+
+            try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                    INSERT OR IGNORE INTO sessions
+                        (session_id, project_dir, first_message, started_at,
+                         turn_count, tool_call_count, scanned_at, source_instance)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+                    """)) {
+                ps.setString(1, sessionId);
+                ps.setString(2, projectDir);
+                ps.setString(3, firstMessage);
+                ps.setString(4, startedAt);
+                ps.setInt(5, turnCount);
+                ps.setInt(6, toolCallCount);
+                ps.setString(7, source);
+                ps.executeUpdate();
+            }
+
+            latestTs = startedAt;
+            count++;
+        }
+
+        if (latestTs != null) {
+            cursorStore.updateSessionCursor(peerId, latestTs);
+            LOG.fine("Pulled " + count + " sessions from " + peerId);
+        }
+    }
+
+    private void pullEvents() throws IOException, InterruptedException, SQLException {
+        String since = cursorStore.getLastEventTs(peerId);
+        String url = baseUrl + "/events/search?q=*&limit=200"
+                + (since != null ? "&since=" + since : "");
+
+        JsonNode response = fetchJson(url);
+        if (response == null) return;
+
+        // EventsHandler returns a JSON array directly (not wrapped in "events")
+        JsonNode events = response;
+        if (!events.isArray()) {
+            events = response.get("events");
+            if (events == null) events = response.get("results");
+        }
+        if (events == null || !events.isArray() || events.isEmpty()) return;
+
+        String latestTs = null;
+        int count = 0;
+
+        for (JsonNode event : events) {
+            // Jackson record serialization uses camelCase (eventTs, sessionId, projectDir)
+            String eventTs = event.path("eventTs").asText(
+                    event.path("event_ts").asText(null));
+            String tool = event.path("tool").asText("Bash");
+            String command = event.path("command").asText("");
+            String sessionId = event.path("sessionId").asText(
+                    event.path("session_id").asText(""));
+            String projectDir = event.path("projectDir").asText(
+                    event.path("project_dir").asText(""));
+            String outputPreview = event.path("outputPreview").asText(
+                    event.path("output_preview").asText(null));
+            String source = event.path("source_instance").asText(peerId);
+            if ("local".equals(source)) source = peerId;
+
+            // Use provided hash or compute it — deduplicates across any sync path
+            String hash = event.path("event_hash").asText(
+                    event.path("eventHash").asText(null));
+            if (hash == null) hash = computeEventHash(eventTs, tool, command, sessionId);
+
+            if (eventTs == null) continue;
+
+            try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                    INSERT OR IGNORE INTO tool_events
+                        (event_ts, session_id, project_dir, tool, command,
+                         output_preview, ingested_at, source_instance, event_hash)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?, ?)
+                    """)) {
+                ps.setString(1, eventTs);
+                ps.setString(2, sessionId);
+                ps.setString(3, projectDir);
+                ps.setString(4, tool);
+                ps.setString(5, command);
+                ps.setString(6, outputPreview);
+                ps.setString(7, source);
+                ps.setString(8, hash);
+                ps.executeUpdate();
+            }
+
+            latestTs = eventTs;
+            count++;
+        }
+
+        if (latestTs != null) {
+            cursorStore.updateEventCursor(peerId, latestTs);
+            LOG.fine("Pulled " + count + " events from " + peerId);
+        }
+    }
+
+    // --- PUSH: send local data to remote ---
+
+    private void pushSessions() throws IOException, InterruptedException, SQLException {
+        String since = cursorStore.getLastPushSessionTs(peerId);
+        String whereClause = since != null ? " WHERE started_at > ?" : "";
+
+        List<JsonNode> localSessions = new ArrayList<>();
+        try (PreparedStatement ps = db.getConnection().prepareStatement(
+                "SELECT session_id, project_dir, first_message, started_at, " +
+                "turn_count, tool_call_count, source_instance " +
+                "FROM sessions" + whereClause + " ORDER BY started_at ASC LIMIT 100")) {
+            if (since != null) ps.setString(1, since);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ObjectNode node = JSON.createObjectNode()
+                            .put("session_id", rs.getString("session_id"))
+                            .put("project_dir", rs.getString("project_dir"))
+                            .put("first_message", rs.getString("first_message"))
+                            .put("started_at", rs.getString("started_at"))
+                            .put("turn_count", rs.getInt("turn_count"))
+                            .put("tool_call_count", rs.getInt("tool_call_count"))
+                            .put("source_instance", rs.getString("source_instance"));
+                    localSessions.add(node);
+                }
+            }
+        }
+
+        if (localSessions.isEmpty()) return;
+
+        String payload = JSON.writeValueAsString(
+                JSON.createObjectNode().set("sessions", JSON.valueToTree(localSessions)));
+
+        HttpResponse<String> response = postJson(baseUrl + "/ingest/sessions", payload);
+        if (response != null && response.statusCode() == 200) {
+            String lastTs = localSessions.get(localSessions.size() - 1).path("started_at").asText();
+            cursorStore.updatePushSessionCursor(peerId, lastTs);
+            LOG.fine("Pushed " + localSessions.size() + " sessions to " + peerId);
+        }
+    }
+
+    private void pushEvents() throws IOException, InterruptedException, SQLException {
+        String since = cursorStore.getLastPushEventTs(peerId);
+        String whereClause = since != null ? " WHERE event_ts > ?" : "";
+
+        List<JsonNode> localEvents = new ArrayList<>();
+        try (PreparedStatement ps = db.getConnection().prepareStatement(
+                "SELECT event_ts, tool, command, session_id, project_dir, " +
+                "output_preview, source_instance, event_hash FROM tool_events" +
+                whereClause + " ORDER BY event_ts ASC LIMIT 200")) {
+            if (since != null) ps.setString(1, since);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ObjectNode node = JSON.createObjectNode()
+                            .put("event_ts", rs.getString("event_ts"))
+                            .put("tool", rs.getString("tool"))
+                            .put("command", rs.getString("command"))
+                            .put("session_id", rs.getString("session_id"))
+                            .put("project_dir", rs.getString("project_dir"))
+                            .put("output_preview", rs.getString("output_preview"))
+                            .put("source_instance", rs.getString("source_instance"))
+                            .put("event_hash", rs.getString("event_hash"));
+                    localEvents.add(node);
+                }
+            }
+        }
+
+        if (localEvents.isEmpty()) return;
+
+        String payload = JSON.writeValueAsString(
+                JSON.createObjectNode().set("events", JSON.valueToTree(localEvents)));
+
+        HttpResponse<String> response = postJson(baseUrl + "/ingest/events", payload);
+        if (response != null && response.statusCode() == 200) {
+            String lastTs = localEvents.get(localEvents.size() - 1).path("event_ts").asText();
+            cursorStore.updatePushEventCursor(peerId, lastTs);
+            LOG.fine("Pushed " + localEvents.size() + " events to " + peerId);
+        }
+    }
+
+    // --- HTTP helpers ---
+
+    private JsonNode fetchJson(String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(15))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            LOG.warning("Peer API returned " + response.statusCode() + " for " + url);
+            return null;
+        }
+        return JSON.readTree(response.body());
+    }
+
+    private HttpResponse<String> postJson(String url, String body)
+            throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(15))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            LOG.warning("Peer ingest returned " + response.statusCode() + " for " + url);
+            return null;
+        }
+        return response;
+    }
+
+    // --- hashing ---
+
+    /**
+     * Compute a SHA-256 hash for event deduplication.
+     * Public so IngestHandler can reuse it.
+     */
+    public static String computeEventHash(String timestamp, String tool, String command, String sessionId) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update((timestamp + "|" + tool + "|" + command + "|" + sessionId)
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/peer/SshTunnel.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/SshTunnel.java
@@ -1,0 +1,177 @@
+package com.cantara.kcp.memory.peer;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+/**
+ * Manages an SSH tunnel to a remote kcp-memory instance.
+ *
+ * <p>Spawns {@code ssh -N -L <localPort>:127.0.0.1:7735 <user>@<host>}
+ * as a child process and monitors its lifecycle. Reconnects with exponential
+ * backoff on failure.
+ *
+ * <p>Uses the system SSH binary, so it inherits ~/.ssh/config, SSH keys,
+ * and SSM ProxyCommand — no Java SSH library needed.
+ */
+public class SshTunnel {
+
+    private static final Logger LOG = Logger.getLogger(SshTunnel.class.getName());
+
+    private static final int REMOTE_PORT = 7735;
+    private static final int INITIAL_BACKOFF_MS = 2_000;
+    private static final int MAX_BACKOFF_MS = 60_000;
+
+    private final String sshUser;
+    private final String sshHost;
+    private final int sshPort;
+    private final int localPort;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private volatile Process sshProcess;
+    private Thread watcherThread;
+
+    /**
+     * @param sshUser SSH username
+     * @param sshHost remote hostname or IP
+     * @param sshPort SSH port (typically 22)
+     */
+    public SshTunnel(String sshUser, String sshHost, int sshPort) {
+        this.sshUser = sshUser;
+        this.sshHost = sshHost;
+        this.sshPort = sshPort;
+        this.localPort = findFreePort();
+    }
+
+    /**
+     * Parse a peer URI into an SshTunnel.
+     * Supports: {@code ssh://user@host} and {@code ssh://user@host:port}
+     *
+     * @return SshTunnel instance, or null if URI is not an SSH URI
+     */
+    public static SshTunnel fromUri(String uri) {
+        if (!uri.startsWith("ssh://")) return null;
+
+        String remainder = uri.substring("ssh://".length());
+        String user, host;
+        int port = 22;
+
+        int atIdx = remainder.indexOf('@');
+        if (atIdx < 0) throw new IllegalArgumentException("SSH URI must include user: ssh://user@host");
+        user = remainder.substring(0, atIdx);
+        String hostPart = remainder.substring(atIdx + 1);
+
+        int colonIdx = hostPart.lastIndexOf(':');
+        if (colonIdx >= 0) {
+            host = hostPart.substring(0, colonIdx);
+            port = Integer.parseInt(hostPart.substring(colonIdx + 1));
+        } else {
+            host = hostPart;
+        }
+
+        return new SshTunnel(user, host, port);
+    }
+
+    /** Start the tunnel. Non-blocking — spawns a watcher thread. */
+    public void start() {
+        if (running.getAndSet(true)) return;
+        LOG.info("Starting SSH tunnel to " + sshUser + "@" + sshHost + ":" + sshPort
+                + " (local port " + localPort + ")");
+
+        watcherThread = Thread.ofVirtual().name("ssh-tunnel-watcher").start(this::watchLoop);
+    }
+
+    /** Stop the tunnel and kill the SSH process. */
+    public void stop() {
+        running.set(false);
+        if (sshProcess != null) {
+            sshProcess.destroyForcibly();
+        }
+        if (watcherThread != null) {
+            watcherThread.interrupt();
+        }
+        LOG.info("SSH tunnel stopped");
+    }
+
+    /** The local port that forwards to remote :7735. */
+    public int getLocalPort() {
+        return localPort;
+    }
+
+    /** True if the SSH process is currently alive. */
+    public boolean isConnected() {
+        return sshProcess != null && sshProcess.isAlive();
+    }
+
+    /** Host identifier for this peer (used as peer_id in cursor table). */
+    public String getPeerId() {
+        return sshUser + "@" + sshHost;
+    }
+
+    // --- internal ---
+
+    private void watchLoop() {
+        while (running.get()) {
+            try {
+                sshProcess = spawnSsh();
+                LOG.info("SSH tunnel established to " + sshHost);
+                consecutiveFailures.set(0);
+
+                // Block until SSH process exits
+                int exitCode = sshProcess.waitFor();
+                if (!running.get()) break; // clean shutdown
+
+                LOG.warning("SSH tunnel exited with code " + exitCode);
+            } catch (IOException e) {
+                LOG.warning("Failed to spawn SSH tunnel: " + e.getMessage());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            // Exponential backoff on reconnect
+            if (running.get()) {
+                int failures = consecutiveFailures.incrementAndGet();
+                int backoff = Math.min(INITIAL_BACKOFF_MS * (1 << (failures - 1)), MAX_BACKOFF_MS);
+                LOG.info("Reconnecting SSH tunnel in " + backoff + "ms (attempt " + failures + ")");
+                try {
+                    Thread.sleep(backoff);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+    }
+
+    private Process spawnSsh() throws IOException {
+        // ssh -N -L localPort:127.0.0.1:7735 -p sshPort user@host
+        // -N: no remote command
+        // -o ServerAliveInterval=30: keepalive every 30s
+        // -o ServerAliveCountMax=3: fail after 3 missed keepalives (90s)
+        // -o ExitOnForwardFailure=yes: exit if port forward fails
+        ProcessBuilder pb = new ProcessBuilder(
+                "ssh", "-N",
+                "-L", localPort + ":127.0.0.1:" + REMOTE_PORT,
+                "-p", String.valueOf(sshPort),
+                "-o", "ServerAliveInterval=30",
+                "-o", "ServerAliveCountMax=3",
+                "-o", "ExitOnForwardFailure=yes",
+                "-o", "StrictHostKeyChecking=accept-new",
+                sshUser + "@" + sshHost
+        );
+        pb.inheritIO();
+        return pb.start();
+    }
+
+    private static int findFreePort() {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException("No free port available for SSH tunnel", e);
+        }
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/server/ExternalHttpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/ExternalHttpServer.java
@@ -1,0 +1,200 @@
+package com.cantara.kcp.memory.server;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * TLS-enabled HTTP server for external (mobile) access to kcp-memory.
+ *
+ * <p>Wraps the same handler dispatch pattern as {@link TcpHttpServer} but:
+ * <ul>
+ *   <li>Binds to an external address (0.0.0.0:8443)</li>
+ *   <li>Requires TLS (PEM cert + key)</li>
+ *   <li>Validates API key on every request before dispatch</li>
+ * </ul>
+ *
+ * <p>Internal endpoints (search, sessions, stats, events) are registered alongside
+ * new mobile-specific endpoints (dispatch, capture, synthesis proxy).
+ */
+public class ExternalHttpServer {
+
+    private static final Logger LOG = Logger.getLogger(ExternalHttpServer.class.getName());
+
+    private final String bindAddress;
+    private final int port;
+    private final String tlsCertPath;
+    private final String tlsKeyPath;
+    private final String apiKey;
+
+    private final Map<String, KcpHandler> handlers = new LinkedHashMap<>();
+    private volatile boolean running = false;
+    private ServerSocket serverSocket;
+
+    /**
+     * @param bindAddress interface to bind (e.g., "0.0.0.0")
+     * @param port        listen port (e.g., 8443)
+     * @param tlsCertPath path to PEM certificate (or PKCS12 keystore)
+     * @param tlsKeyPath  path to PEM private key (or keystore password file)
+     * @param apiKey      required Bearer token for all requests
+     */
+    public ExternalHttpServer(String bindAddress, int port,
+                              String tlsCertPath, String tlsKeyPath, String apiKey) {
+        this.bindAddress = bindAddress;
+        this.port = port;
+        this.tlsCertPath = tlsCertPath;
+        this.tlsKeyPath = tlsKeyPath;
+        this.apiKey = apiKey;
+    }
+
+    /** Register a handler for the given path prefix. */
+    public void createContext(String path, KcpHandler handler) {
+        handlers.put(path, handler);
+    }
+
+    /** Bind with TLS and start the acceptor. */
+    public void start() throws Exception {
+        if (tlsCertPath != null && tlsKeyPath != null) {
+            serverSocket = createTlsServerSocket();
+        } else {
+            // Fallback to plain TCP (for development / reverse proxy setups)
+            LOG.warning("No TLS cert/key provided -- external server running WITHOUT TLS");
+            serverSocket = new ServerSocket();
+            serverSocket.setReuseAddress(true);
+            serverSocket.bind(new InetSocketAddress(bindAddress, port));
+        }
+
+        running = true;
+
+        Thread.ofVirtual().name("external-acceptor").start(() -> {
+            while (running) {
+                try {
+                    Socket conn = serverSocket.accept();
+                    Thread.ofVirtual().start(() -> dispatch(conn));
+                } catch (IOException e) {
+                    if (running) LOG.fine("External acceptor error: " + e.getMessage());
+                }
+            }
+        });
+
+        LOG.info("External API server started on " + bindAddress + ":" + port
+                + (tlsCertPath != null ? " (TLS)" : " (PLAINTEXT)"));
+    }
+
+    /** Stop the external server. */
+    public void stop() {
+        running = false;
+        try {
+            if (serverSocket != null) serverSocket.close();
+        } catch (IOException ignored) {
+        }
+    }
+
+    // --- internal ---
+
+    private void dispatch(Socket conn) {
+        try (TcpExchange ex = new TcpExchange(conn)) {
+            // API key check before any handler
+            if (!authenticateRequest(ex)) return;
+
+            // CORS preflight
+            if ("OPTIONS".equalsIgnoreCase(ex.getRequestMethod())) {
+                sendCorsOk(ex);
+                return;
+            }
+
+            KcpHandler handler = resolve(ex.getRequestURI().getPath());
+            if (handler != null) {
+                handler.handle(ex);
+            } else {
+                ex.sendResponse(404, "application/json; charset=utf-8",
+                        "{\"error\":\"Not found\"}".getBytes());
+            }
+        } catch (IOException e) {
+            LOG.fine("External request error: " + e.getMessage());
+        }
+    }
+
+    private boolean authenticateRequest(TcpExchange ex) throws IOException {
+        // Skip auth for OPTIONS (CORS preflight)
+        if ("OPTIONS".equalsIgnoreCase(ex.getRequestMethod())) return true;
+
+        String authHeader = ex.getRequestHeader("Authorization");
+        if (authHeader == null || !authHeader.equals("Bearer " + apiKey)) {
+            ex.sendResponse(401, "application/json; charset=utf-8",
+                    "{\"error\":\"Unauthorized\"}".getBytes());
+            return false;
+        }
+        return true;
+    }
+
+    private void sendCorsOk(TcpExchange ex) throws IOException {
+        ex.sendResponse(204, "text/plain", new byte[0]);
+    }
+
+    private KcpHandler resolve(String path) {
+        KcpHandler exact = handlers.get(path);
+        if (exact != null) return exact;
+
+        KcpHandler best = null;
+        int bestLen = -1;
+        for (Map.Entry<String, KcpHandler> entry : handlers.entrySet()) {
+            String prefix = entry.getKey();
+            if (path.startsWith(prefix) && prefix.length() > bestLen) {
+                best = entry.getValue();
+                bestLen = prefix.length();
+            }
+        }
+        return best;
+    }
+
+    private ServerSocket createTlsServerSocket() throws Exception {
+        // Load PKCS12 keystore (convert PEM to PKCS12 with:
+        //   openssl pkcs12 -export -in cert.pem -inkey key.pem -out keystore.p12 -password pass:changeit)
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream fis = new FileInputStream(tlsCertPath)) {
+            // tlsKeyPath is either the keystore password directly, or a file containing it
+            String password = readPassword(tlsKeyPath);
+            ks.load(fis, password.toCharArray());
+
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(ks, password.toCharArray());
+
+            SSLContext ctx = SSLContext.getInstance("TLS");
+            ctx.init(kmf.getKeyManagers(), null, null);
+
+            SSLServerSocketFactory factory = ctx.getServerSocketFactory();
+            SSLServerSocket ss = (SSLServerSocket) factory.createServerSocket();
+            ss.setReuseAddress(true);
+            ss.bind(new InetSocketAddress(bindAddress, port));
+
+            // Only allow TLS 1.2+
+            ss.setEnabledProtocols(new String[]{"TLSv1.2", "TLSv1.3"});
+
+            return ss;
+        }
+    }
+
+    private String readPassword(String pathOrPassword) {
+        // If it looks like a file path, try reading it
+        try {
+            java.nio.file.Path p = java.nio.file.Path.of(pathOrPassword);
+            if (java.nio.file.Files.exists(p)) {
+                return new String(java.nio.file.Files.readAllBytes(p)).trim();
+            }
+        } catch (Exception ignored) {
+        }
+        // Otherwise treat it as the password itself
+        return pathOrPassword;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
@@ -19,20 +19,25 @@ import java.util.Map;
  */
 public class TcpExchange implements Closeable {
 
-    private static final Map<Integer, String> STATUS_TEXT = Map.of(
+    private static final Map<Integer, String> STATUS_TEXT = new HashMap<>(Map.of(
             200, "OK",
+            201, "Created",
             202, "Accepted",
+            204, "No Content",
             400, "Bad Request",
+            401, "Unauthorized",
             404, "Not Found",
             405, "Method Not Allowed",
-            500, "Internal Server Error"
-    );
+            500, "Internal Server Error",
+            502, "Bad Gateway"
+    ));
 
     private final Socket socket;
     private final OutputStream out;
     private final String method;
     private final URI uri;
     private final byte[] requestBody;
+    private final Map<String, String> requestHeaders = new HashMap<>();
 
     public TcpExchange(Socket socket) throws IOException {
         this.socket = socket;
@@ -56,9 +61,10 @@ public class TcpExchange implements Closeable {
         while ((line = readLine(in)) != null && !line.isEmpty()) {
             int colon = line.indexOf(':');
             if (colon > 0) {
-                String key = line.substring(0, colon).trim().toLowerCase();
+                String key = line.substring(0, colon).trim();
                 String value = line.substring(colon + 1).trim();
-                if ("content-length".equals(key)) {
+                requestHeaders.put(key, value);
+                if ("content-length".equalsIgnoreCase(key)) {
                     try { contentLength = Integer.parseInt(value); }
                     catch (NumberFormatException ignored) {}
                 }
@@ -84,6 +90,49 @@ public class TcpExchange implements Closeable {
     public URI getRequestURI() { return uri; }
 
     public InputStream getRequestBody() { return new ByteArrayInputStream(requestBody); }
+
+    /**
+     * Get a request header value by name (case-insensitive lookup).
+     *
+     * @param name header name (e.g. "Authorization")
+     * @return the header value, or null if not present
+     */
+    public String getRequestHeader(String name) {
+        // Case-insensitive lookup
+        for (Map.Entry<String, String> entry : requestHeaders.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(name)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Send HTTP response headers for streaming (no Content-Length).
+     * After calling this, write directly to {@link #getOutputStream()} and flush.
+     *
+     * @param statusCode  HTTP status
+     * @param contentType value for Content-Type header
+     */
+    public void sendStreamingHeaders(int statusCode, String contentType) throws IOException {
+        String reason = STATUS_TEXT.getOrDefault(statusCode, "Unknown");
+        StringBuilder sb = new StringBuilder();
+        sb.append("HTTP/1.1 ").append(statusCode).append(' ').append(reason).append("\r\n");
+        sb.append("Content-Type: ").append(contentType).append("\r\n");
+        sb.append("Transfer-Encoding: chunked\r\n");
+        sb.append("Connection: close\r\n");
+        sb.append("\r\n");
+        out.write(sb.toString().getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    /**
+     * Get the raw output stream for streaming responses.
+     * Call {@link #sendStreamingHeaders(int, String)} first.
+     */
+    public OutputStream getOutputStream() {
+        return out;
+    }
 
     /**
      * Send a complete HTTP response and flush.

--- a/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
@@ -73,7 +73,8 @@ public class MemoryDatabase implements AutoCloseable {
                 "/db/V2__tool_events.sql",
                 "/db/V3__agent_sessions.sql",
                 "/db/V4__output_preview.sql",
-                "/db/V5__manifest_version.sql"}) {
+                "/db/V5__manifest_version.sql",
+                "/db/V6__peer_sync.sql"}) {
 
             String version = resource.substring(resource.lastIndexOf('/') + 1, resource.lastIndexOf('.'));
 
@@ -121,7 +122,9 @@ public class MemoryDatabase implements AutoCloseable {
                 new MigrationCheck("V4__output_preview",
                         "SELECT 1 FROM pragma_table_info('tool_events') WHERE name='output_preview'"),
                 new MigrationCheck("V5__manifest_version",
-                        "SELECT 1 FROM pragma_table_info('tool_events') WHERE name='manifest_version'")
+                        "SELECT 1 FROM pragma_table_info('tool_events') WHERE name='manifest_version'"),
+                new MigrationCheck("V6__peer_sync",
+                        "SELECT 1 FROM pragma_table_info('sessions') WHERE name='source_instance'")
         );
         for (MigrationCheck check : checks) {
             boolean present;

--- a/java/src/main/java/com/cantara/kcp/memory/store/PeerCursorStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/PeerCursorStore.java
@@ -1,0 +1,106 @@
+package com.cantara.kcp.memory.store;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+/**
+ * Tracks replication cursors per peer — how far we've synced sessions,
+ * events, and agent sessions from each remote instance.
+ *
+ * <p>Uses the {@code peer_cursors} table (V6 migration).
+ */
+public class PeerCursorStore {
+
+    private static final Logger LOG = Logger.getLogger(PeerCursorStore.class.getName());
+
+    private final MemoryDatabase db;
+
+    public PeerCursorStore(MemoryDatabase db) {
+        this.db = db;
+    }
+
+    /** Get the last synced session timestamp for a peer, or null if never synced. */
+    public String getLastSessionTs(String peerId) {
+        return getCursorField(peerId, "last_session_ts");
+    }
+
+    /** Get the last synced event timestamp for a peer, or null if never synced. */
+    public String getLastEventTs(String peerId) {
+        return getCursorField(peerId, "last_event_ts");
+    }
+
+    /** Get the last synced agent session timestamp for a peer, or null if never synced. */
+    public String getLastAgentTs(String peerId) {
+        return getCursorField(peerId, "last_agent_ts");
+    }
+
+    /** Update the session sync cursor for a peer. */
+    public void updateSessionCursor(String peerId, String timestamp) {
+        upsertCursor(peerId, "last_session_ts", timestamp);
+    }
+
+    /** Update the event sync cursor for a peer. */
+    public void updateEventCursor(String peerId, String timestamp) {
+        upsertCursor(peerId, "last_event_ts", timestamp);
+    }
+
+    /** Update the agent session sync cursor for a peer. */
+    public void updateAgentCursor(String peerId, String timestamp) {
+        upsertCursor(peerId, "last_agent_ts", timestamp);
+    }
+
+    /** Get the last pushed session timestamp for a peer, or null if never pushed. */
+    public String getLastPushSessionTs(String peerId) {
+        return getCursorField(peerId, "last_push_session_ts");
+    }
+
+    /** Get the last pushed event timestamp for a peer, or null if never pushed. */
+    public String getLastPushEventTs(String peerId) {
+        return getCursorField(peerId, "last_push_event_ts");
+    }
+
+    /** Update the push session cursor for a peer. */
+    public void updatePushSessionCursor(String peerId, String timestamp) {
+        upsertCursor(peerId, "last_push_session_ts", timestamp);
+    }
+
+    /** Update the push event cursor for a peer. */
+    public void updatePushEventCursor(String peerId, String timestamp) {
+        upsertCursor(peerId, "last_push_event_ts", timestamp);
+    }
+
+    // --- internal ---
+
+    private String getCursorField(String peerId, String field) {
+        // field is always a compile-time constant from this class, safe for SQL
+        String sql = "SELECT " + field + " FROM peer_cursors WHERE peer_id = ?";
+        try (PreparedStatement ps = db.getConnection().prepareStatement(sql)) {
+            ps.setString(1, peerId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) return rs.getString(1);
+            }
+        } catch (SQLException e) {
+            LOG.warning("Failed to read cursor for peer " + peerId + ": " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void upsertCursor(String peerId, String field, String value) {
+        // SQLite UPSERT: insert or update on conflict
+        String sql = """
+                INSERT INTO peer_cursors (peer_id, %s, updated_at)
+                VALUES (?, ?, datetime('now'))
+                ON CONFLICT(peer_id) DO UPDATE SET %s = excluded.%s, updated_at = datetime('now')
+                """.formatted(field, field, field);
+        try (PreparedStatement ps = db.getConnection().prepareStatement(sql)) {
+            ps.setString(1, peerId);
+            ps.setString(2, value);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            LOG.warning("Failed to update cursor for peer " + peerId + ": " + e.getMessage());
+        }
+    }
+}

--- a/java/src/main/resources/db/V6__peer_sync.sql
+++ b/java/src/main/resources/db/V6__peer_sync.sql
@@ -1,0 +1,29 @@
+-- V6: Peer synchronization support
+-- Adds source-instance tracking, event deduplication hashes,
+-- replication cursors, and a peer ingest endpoint table.
+
+-- Tag existing records as local
+ALTER TABLE sessions ADD COLUMN source_instance TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE tool_events ADD COLUMN source_instance TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE agent_sessions ADD COLUMN source_instance TEXT NOT NULL DEFAULT 'local';
+
+-- Event deduplication hash — prevents duplicates in transitive sync (hub-and-spoke).
+-- SHA-256 of (timestamp + tool + command + session_id). Globally unique.
+ALTER TABLE tool_events ADD COLUMN event_hash TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_hash ON tool_events(event_hash);
+
+-- Replication cursor per peer — tracks how far we've synced in each direction
+CREATE TABLE IF NOT EXISTS peer_cursors (
+    peer_id            TEXT PRIMARY KEY,
+    last_session_ts    TEXT,           -- ISO-8601: last session pulled from this peer
+    last_event_ts      TEXT,           -- ISO-8601: last event pulled from this peer
+    last_agent_ts      TEXT,           -- ISO-8601: last agent session pulled from this peer
+    last_push_session_ts TEXT,         -- ISO-8601: last local session pushed to this peer
+    last_push_event_ts   TEXT,         -- ISO-8601: last local event pushed to this peer
+    updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Index for efficient filtering by source
+CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source_instance);
+CREATE INDEX IF NOT EXISTS idx_events_source ON tool_events(source_instance);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_source ON agent_sessions(source_instance);


### PR DESCRIPTION
## Summary

Implements the ExoCortex mobile architecture designed in exoreaction/lib-pcb#245 and #246.

- **`--peer ssh://user@host`** — bidirectional sync between kcp-memory instances via SSH tunnel. Supports hub-and-spoke topology (laptop + EC2-A + EC2-B). Events deduplicated via SHA-256 hash.
- **`--serve host:port`** — TLS + Bearer token protected external API for mobile clients. Handlers: /dispatch (stream claude output), /capture (ingest voice/photo/notes), /synthesis/search (proxy), /ingest/{sessions,events} (push receiver).

## New components

- `peer/SshTunnel` — SSH tunnel with auto-reconnect + exponential backoff
- `peer/PeerSyncService` — poll + push sync, transitive propagation, deduplication
- `store/PeerCursorStore` — replication cursor per peer
- `server/ExternalHttpServer` — TLS ServerSocket, Bearer auth middleware
- `handler/CaptureHandler` — POST /capture
- `handler/DispatchHandler` — POST /dispatch
- `handler/IngestHandler` — POST /ingest/{sessions,events}
- `handler/SynthesisProxyHandler` — GET /synthesis/search

## Modified components

- `server/TcpExchange` — added `getRequestHeader()`, `sendStreamingHeaders()`, `getOutputStream()`, expanded status code map (201, 204, 401, 502)
- `store/MemoryDatabase` — registered V6 migration + backfill check
- `KcpMemoryDaemon` — wiring for peer sync services + external server + IngestHandler on internal API
- `cli/KcpMemoryCli` — new CLI flags: `--peer`, `--serve`, `--tls-cert`, `--tls-key`, `--api-key`, `--capture-dir`, `--synthesis-cmd`

## Schema

V6 migration: `source_instance` column on sessions/tool_events/agent_sessions, `event_hash` unique index on tool_events, `peer_cursors` table.

## Skills

Three new Claude Code skills added to `.claude/skills/`:
- `exocortex-peer-setup` — configure and test --peer connections
- `exocortex-serve-setup` — configure and test --serve external API
- `exocortex-debug` — diagnose sync issues, check event flow

## Test plan
- [x] `mvn clean test` — all 33 existing tests pass
- [ ] `--peer` flag accepts multiple values (repeatable)
- [ ] SSH tunnel establishes and reconnects on failure
- [ ] Events sync bidirectionally between two instances
- [ ] `event_hash` deduplication prevents duplicates
- [ ] `/ingest` accepts pushed data
- [ ] `--serve` starts TLS server, rejects requests without valid Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)