### PR TITLE
feat: ExoCortex control plane Phase 1 — WebSocket nodes and event broadcast

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
+++ b/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
@@ -2,10 +2,12 @@ package com.cantara.kcp.memory;
 
 import com.cantara.kcp.memory.handler.*;
 import com.cantara.kcp.memory.mcp.McpServer;
+import com.cantara.kcp.memory.peer.NodeRegistry;
 import com.cantara.kcp.memory.peer.PeerSyncService;
 import com.cantara.kcp.memory.scanner.AgentSessionScanner;
 import com.cantara.kcp.memory.scanner.EventLogScanner;
 import com.cantara.kcp.memory.scanner.SessionScanner;
+import com.cantara.kcp.memory.server.EventBroadcaster;
 import com.cantara.kcp.memory.server.ExternalHttpServer;
 import com.cantara.kcp.memory.server.TcpHttpServer;
 import com.cantara.kcp.memory.store.MemoryDatabase;
@@ -43,6 +45,8 @@ public class KcpMemoryDaemon {
     public  static final int    PORT = 7735;
 
     private final MemoryDatabase db;
+    private final NodeRegistry nodeRegistry = new NodeRegistry();
+    private final EventBroadcaster broadcaster = new EventBroadcaster();
     private TcpHttpServer server;
     private ScheduledExecutorService scheduler;
     private final List<PeerSyncService> peerSyncServices = new ArrayList<>();
@@ -55,13 +59,17 @@ public class KcpMemoryDaemon {
     public void start() throws Exception {
         server = new TcpHttpServer(PORT);
 
+        IngestHandler ingestHandler = new IngestHandler(db);
+        ingestHandler.setBroadcaster(broadcaster);
+
         server.createContext("/health",        new HealthHandler(db));
         server.createContext("/search",        new SearchHandler(db));
         server.createContext("/sessions",      new ListHandler(db));
         server.createContext("/stats",         new StatsHandler(db));
         server.createContext("/scan",          new ScanHandler(db));
         server.createContext("/events/search", new EventsHandler(db));
-        server.createContext("/ingest",        new IngestHandler(db));
+        server.createContext("/ingest",        ingestHandler);
+        server.createContext("/nodes",         new NodesHandler(nodeRegistry));
 
         server.start();
         LOG.info("kcp-memory daemon started on port " + PORT);
@@ -122,6 +130,7 @@ public class KcpMemoryDaemon {
      */
     public void startPeerSync(String peerUri, String localInstanceId) {
         PeerSyncService sync = new PeerSyncService(db, peerUri, localInstanceId);
+        sync.setNodeRegistry(nodeRegistry);
         sync.start();
         peerSyncServices.add(sync);
     }
@@ -141,6 +150,10 @@ public class KcpMemoryDaemon {
         externalServer.createContext("/sessions", new ListHandler(db));
         externalServer.createContext("/stats", new StatsHandler(db));
         externalServer.createContext("/events/search", new EventsHandler(db));
+
+        // Control plane endpoints
+        externalServer.createContext("/nodes", new NodesHandler(nodeRegistry));
+        externalServer.createContext("/ws", new WsHandler(broadcaster));
 
         // Mobile-specific endpoints
         externalServer.createContext("/dispatch", new DispatchHandler());

--- a/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
@@ -1,6 +1,7 @@
 package com.cantara.kcp.memory.handler;
 
 import com.cantara.kcp.memory.peer.PeerSyncService;
+import com.cantara.kcp.memory.server.EventBroadcaster;
 import com.cantara.kcp.memory.server.TcpExchange;
 import com.cantara.kcp.memory.store.MemoryDatabase;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -33,9 +34,18 @@ public class IngestHandler extends BaseHandler {
     private static final ObjectMapper JSON = new ObjectMapper();
 
     private final MemoryDatabase db;
+    private EventBroadcaster broadcaster;
 
     public IngestHandler(MemoryDatabase db) {
         this.db = db;
+    }
+
+    /**
+     * Set an optional EventBroadcaster to fan-out ingested events to WebSocket clients.
+     * If not set, ingested events are still stored but not broadcast.
+     */
+    public void setBroadcaster(EventBroadcaster broadcaster) {
+        this.broadcaster = broadcaster;
     }
 
     @Override
@@ -141,7 +151,24 @@ public class IngestHandler extends BaseHandler {
                 ps.setString(6, outputPreview);
                 ps.setString(7, source);
                 ps.setString(8, hash);
-                count += ps.executeUpdate();
+                int inserted = ps.executeUpdate();
+                count += inserted;
+
+                // Broadcast to WebSocket subscribers if event was actually inserted
+                if (inserted > 0 && broadcaster != null) {
+                    try {
+                        String broadcastJson = JSON.writeValueAsString(Map.of(
+                                "type", "tool_event",
+                                "peerId", source,
+                                "tool", tool,
+                                "command", command,
+                                "timestamp", eventTs
+                        ));
+                        broadcaster.broadcast(broadcastJson);
+                    } catch (Exception e) {
+                        LOG.fine("Broadcast failed for event: " + e.getMessage());
+                    }
+                }
             }
         }
         LOG.fine("Ingested " + count + " events from peer push");

--- a/java/src/main/java/com/cantara/kcp/memory/handler/NodesHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/NodesHandler.java
@@ -1,0 +1,52 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.peer.NodeRegistry;
+import com.cantara.kcp.memory.server.TcpExchange;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GET /nodes — returns JSON array of connected peer nodes.
+ *
+ * <p>Response format:
+ * <pre>
+ * [
+ *   {"peerId":"laptop","address":"ssh://user@host","lastSeen":"2026-04-12T17:00:00Z",
+ *    "status":"ok","sessionCount":42,"eventCount":1337},
+ *   ...
+ * ]
+ * </pre>
+ */
+public class NodesHandler extends BaseHandler {
+
+    private final NodeRegistry registry;
+
+    public NodesHandler(NodeRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"GET".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        List<NodeRegistry.NodeInfo> nodes = registry.list();
+
+        List<Map<String, Object>> result = nodes.stream()
+                .map(n -> Map.<String, Object>of(
+                        "peerId", n.peerId(),
+                        "address", n.address(),
+                        "lastSeen", n.lastSeen().toString(),
+                        "status", n.status(),
+                        "sessionCount", n.sessionCount(),
+                        "eventCount", n.eventCount()
+                ))
+                .toList();
+
+        sendJson(ex, 200, result);
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/handler/WsHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/WsHandler.java
@@ -1,0 +1,105 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.EventBroadcaster;
+import com.cantara.kcp.memory.server.TcpExchange;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.logging.Logger;
+
+/**
+ * WebSocket upgrade handler for GET /ws.
+ *
+ * <p>Handles the WebSocket handshake:
+ * <ol>
+ *   <li>Reads {@code Sec-WebSocket-Key} from request headers</li>
+ *   <li>Computes {@code Sec-WebSocket-Accept} per RFC 6455</li>
+ *   <li>Sends 101 Switching Protocols response</li>
+ *   <li>Registers client with {@link EventBroadcaster}</li>
+ *   <li>Blocks reading frames until client disconnects</li>
+ *   <li>Unsubscribes on disconnect</li>
+ * </ol>
+ */
+public class WsHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(WsHandler.class.getName());
+    private static final String WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    private final EventBroadcaster broadcaster;
+
+    public WsHandler(EventBroadcaster broadcaster) {
+        this.broadcaster = broadcaster;
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        String wsKey = ex.getRequestHeader("Sec-WebSocket-Key");
+        if (wsKey == null || wsKey.isBlank()) {
+            sendError(ex, 400, "Missing Sec-WebSocket-Key header");
+            return;
+        }
+
+        String acceptValue = computeAccept(wsKey);
+
+        // Write 101 response directly to the output stream (not via sendResponse,
+        // which sets Connection: close)
+        OutputStream out = ex.getOutputStream();
+        String response = "HTTP/1.1 101 Switching Protocols\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Accept: " + acceptValue + "\r\n"
+                + "\r\n";
+        out.write(response.getBytes(StandardCharsets.UTF_8));
+        out.flush();
+
+        // Subscribe this client's output stream to the broadcaster
+        broadcaster.subscribe(out);
+        LOG.fine("WebSocket client connected, subscribers: " + broadcaster.subscriberCount());
+
+        try {
+            // Block reading frames from the raw socket input stream.
+            // When the client disconnects, read() returns -1 (EOF) or throws IOException.
+            InputStream in = ex.getInputStream();
+            keepAlive(in);
+        } finally {
+            broadcaster.unsubscribe(out);
+            LOG.fine("WebSocket client disconnected, subscribers: " + broadcaster.subscriberCount());
+        }
+    }
+
+    /**
+     * Block reading from the WebSocket input stream until the client disconnects.
+     * Any incoming frames (close, ping, text) are consumed but not processed.
+     * EOF or IOException signals disconnection.
+     */
+    private void keepAlive(InputStream in) {
+        try {
+            byte[] buf = new byte[1024];
+            while (true) {
+                int read = in.read(buf);
+                if (read == -1) break; // EOF — client disconnected
+            }
+        } catch (IOException e) {
+            // Connection closed — expected
+        }
+    }
+
+    /**
+     * Compute Sec-WebSocket-Accept per RFC 6455 section 4.2.2:
+     * Base64(SHA-1(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+     */
+    static String computeAccept(String key) {
+        try {
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+            sha1.update((key + WS_GUID).getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(sha1.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-1 not available", e);
+        }
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/peer/NodeRegistry.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/NodeRegistry.java
@@ -1,0 +1,95 @@
+package com.cantara.kcp.memory.peer;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Thread-safe registry of connected peer nodes in the ExoCortex mesh.
+ *
+ * <p>Tracks peer identity, address, health metrics, and last-seen timestamps
+ * for the control plane's {@code /nodes} endpoint.
+ */
+public class NodeRegistry {
+
+    /**
+     * Immutable snapshot of a registered peer node's state.
+     */
+    public record NodeInfo(
+            String peerId,
+            String address,
+            Instant lastSeen,
+            String status,
+            long sessionCount,
+            long eventCount
+    ) {}
+
+    private record MutableNode(
+            String peerId,
+            String address,
+            Instant lastSeen,
+            String status,
+            long sessionCount,
+            long eventCount
+    ) {
+        NodeInfo toInfo() {
+            return new NodeInfo(peerId, address, lastSeen, status, sessionCount, eventCount);
+        }
+    }
+
+    private final ConcurrentMap<String, MutableNode> nodes = new ConcurrentHashMap<>();
+
+    /**
+     * Register a peer node. If already registered, updates the address and resets lastSeen.
+     */
+    public void register(String peerId, String address) {
+        nodes.put(peerId, new MutableNode(peerId, address, Instant.now(), "ok", 0, 0));
+    }
+
+    /**
+     * Update health metrics for a peer.
+     */
+    public void updateHealth(String peerId, long sessionCount, long eventCount) {
+        nodes.computeIfPresent(peerId, (id, old) ->
+                new MutableNode(id, old.address, Instant.now(), old.status, sessionCount, eventCount));
+    }
+
+    /**
+     * Update the lastSeen timestamp for a peer.
+     */
+    public void markSeen(String peerId) {
+        nodes.computeIfPresent(peerId, (id, old) ->
+                new MutableNode(id, old.address, Instant.now(), old.status, old.sessionCount, old.eventCount));
+    }
+
+    /**
+     * Remove a peer from the registry.
+     */
+    public void remove(String peerId) {
+        nodes.remove(peerId);
+    }
+
+    /**
+     * Return a snapshot of all registered nodes, sorted by peerId alphabetically.
+     */
+    public List<NodeInfo> list() {
+        return nodes.values().stream()
+                .map(MutableNode::toInfo)
+                .sorted(Comparator.comparing(NodeInfo::peerId))
+                .toList();
+    }
+
+    /**
+     * Check if a peer's lastSeen timestamp is older than the given threshold.
+     *
+     * @return true if the peer exists and is stale; false if the peer doesn't exist or is fresh
+     */
+    public boolean isStale(String peerId, Duration threshold) {
+        MutableNode node = nodes.get(peerId);
+        if (node == null) return false;
+        return Duration.between(node.lastSeen, Instant.now()).compareTo(threshold) > 0;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
@@ -67,6 +67,7 @@ public class PeerSyncService {
     private String peerId;
     private HttpClient httpClient;
     private ScheduledExecutorService scheduler;
+    private NodeRegistry nodeRegistry;
 
     /**
      * @param db              local database
@@ -128,6 +129,15 @@ public class PeerSyncService {
         return peerId;
     }
 
+    /**
+     * Set a NodeRegistry to track peer health and presence.
+     * After each successful sync cycle, the peer is marked as seen and
+     * health metrics are updated.
+     */
+    public void setNodeRegistry(NodeRegistry registry) {
+        this.nodeRegistry = registry;
+    }
+
     // --- sync cycle ---
 
     private void syncOnce() {
@@ -136,6 +146,23 @@ public class PeerSyncService {
             pullEvents();
             pushSessions();
             pushEvents();
+
+            // Update node registry after successful sync
+            if (nodeRegistry != null && peerId != null) {
+                nodeRegistry.register(peerId, peerUri);
+                nodeRegistry.markSeen(peerId);
+                // Fetch peer health stats
+                try {
+                    JsonNode health = fetchJson(baseUrl + "/health");
+                    if (health != null) {
+                        long sessions = health.path("sessions").asLong(0);
+                        // Use sessions as sessionCount; eventCount from stats if available
+                        nodeRegistry.updateHealth(peerId, sessions, 0);
+                    }
+                } catch (Exception e) {
+                    LOG.fine("Could not fetch peer health for registry: " + e.getMessage());
+                }
+            }
         } catch (Exception e) {
             LOG.warning("Peer sync failed for " + peerId + ": " + e.getMessage());
         }

--- a/java/src/main/java/com/cantara/kcp/memory/server/EventBroadcaster.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/EventBroadcaster.java
@@ -1,0 +1,66 @@
+package com.cantara.kcp.memory.server;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Logger;
+
+/**
+ * Fan-out broadcaster for new events to all connected WebSocket clients.
+ *
+ * <p>Each subscriber is an {@link OutputStream} representing a WebSocket connection.
+ * When {@link #broadcast(String)} is called, the JSON event is encoded as a WebSocket
+ * text frame and written to every subscriber. Dead subscribers (closed streams) are
+ * silently removed.
+ */
+public class EventBroadcaster {
+
+    private static final Logger LOG = Logger.getLogger(EventBroadcaster.class.getName());
+
+    private final List<OutputStream> subscribers = new CopyOnWriteArrayList<>();
+
+    /**
+     * Add a WebSocket client's output stream as a subscriber.
+     */
+    public void subscribe(OutputStream clientOut) {
+        subscribers.add(clientOut);
+    }
+
+    /**
+     * Remove a WebSocket client's output stream on disconnect.
+     */
+    public void unsubscribe(OutputStream clientOut) {
+        subscribers.remove(clientOut);
+    }
+
+    /**
+     * Broadcast a JSON event string to all connected WebSocket clients.
+     * The string is encoded as a WebSocket text frame before sending.
+     * Dead subscribers are silently removed.
+     *
+     * @param jsonEvent the JSON string to broadcast
+     */
+    public void broadcast(String jsonEvent) {
+        if (subscribers.isEmpty()) return;
+
+        byte[] frame = WebSocketFrame.encode(jsonEvent);
+
+        for (OutputStream out : subscribers) {
+            try {
+                out.write(frame);
+                out.flush();
+            } catch (IOException e) {
+                LOG.fine("Removing dead subscriber: " + e.getMessage());
+                subscribers.remove(out);
+            }
+        }
+    }
+
+    /**
+     * Return the number of currently subscribed clients.
+     */
+    public int subscriberCount() {
+        return subscribers.size();
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
@@ -33,6 +33,7 @@ public class TcpExchange implements Closeable {
     ));
 
     private final Socket socket;
+    private final InputStream in;
     private final OutputStream out;
     private final String method;
     private final URI uri;
@@ -42,8 +43,9 @@ public class TcpExchange implements Closeable {
     public TcpExchange(Socket socket) throws IOException {
         this.socket = socket;
         this.out = socket.getOutputStream();
+        this.in = socket.getInputStream();
 
-        InputStream in = socket.getInputStream();
+        InputStream in = this.in;
 
         // --- Parse request line and headers byte-by-byte (safe with binary body) ---
         String requestLine = readLine(in);
@@ -132,6 +134,17 @@ public class TcpExchange implements Closeable {
      */
     public OutputStream getOutputStream() {
         return out;
+    }
+
+    /**
+     * Get the raw input stream from the underlying socket.
+     *
+     * <p>After the HTTP request line, headers, and body have been parsed in the constructor,
+     * this stream is positioned after the request body. For WebSocket upgrades (Content-Length: 0),
+     * this is where WebSocket frames will appear.
+     */
+    public InputStream getInputStream() {
+        return in;
     }
 
     /**

--- a/java/src/main/java/com/cantara/kcp/memory/server/WebSocketFrame.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/WebSocketFrame.java
@@ -1,0 +1,111 @@
+package com.cantara.kcp.memory.server;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * WebSocket RFC 6455 frame encoder/decoder for text frames.
+ *
+ * <p>Supports:
+ * <ul>
+ *   <li>Encoding text frames (server-to-client, unmasked)</li>
+ *   <li>Decoding text frames (handles both masked client frames and unmasked server frames)</li>
+ *   <li>7-bit and 16-bit payload length (no 64-bit needed for our use case)</li>
+ * </ul>
+ */
+public final class WebSocketFrame {
+
+    private WebSocketFrame() {} // utility class
+
+    /**
+     * Encode a UTF-8 string as a WebSocket text frame (FIN, opcode 0x1, no masking).
+     *
+     * @param text the string to encode
+     * @return the complete WebSocket frame bytes
+     */
+    public static byte[] encode(String text) {
+        byte[] payload = text.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream frame = new ByteArrayOutputStream(payload.length + 4);
+
+        // First byte: FIN (0x80) + text opcode (0x01)
+        frame.write(0x81);
+
+        // Second byte: no mask (0x00) + payload length
+        if (payload.length < 126) {
+            frame.write(payload.length);
+        } else {
+            // 16-bit extended length
+            frame.write(126);
+            frame.write((payload.length >> 8) & 0xFF);
+            frame.write(payload.length & 0xFF);
+        }
+
+        // Payload (no masking for server-to-client)
+        frame.write(payload, 0, payload.length);
+
+        return frame.toByteArray();
+    }
+
+    /**
+     * Read and decode one WebSocket frame from a stream.
+     *
+     * <p>Handles masked frames (client-to-server) and unmasked frames.
+     * Assumes FIN bit is set (no fragmentation). Only text frames (opcode 0x1) are expected.
+     *
+     * @param in the input stream to read from
+     * @return the decoded text content
+     * @throws IOException if the stream is closed or frame is malformed
+     */
+    public static String decode(InputStream in) throws IOException {
+        // First byte: FIN + opcode
+        int firstByte = in.read();
+        if (firstByte == -1) throw new IOException("Unexpected end of stream reading frame header");
+
+        // Second byte: MASK flag + payload length
+        int secondByte = in.read();
+        if (secondByte == -1) throw new IOException("Unexpected end of stream reading frame length");
+
+        boolean masked = (secondByte & 0x80) != 0;
+        int payloadLength = secondByte & 0x7F;
+
+        if (payloadLength == 126) {
+            // 16-bit extended length (big-endian)
+            int b1 = in.read();
+            int b2 = in.read();
+            if (b1 == -1 || b2 == -1) throw new IOException("Unexpected end of stream reading extended length");
+            payloadLength = (b1 << 8) | b2;
+        }
+        // Note: payloadLength == 127 (64-bit) is not supported
+
+        // Read masking key if present
+        byte[] maskKey = null;
+        if (masked) {
+            maskKey = new byte[4];
+            readFully(in, maskKey);
+        }
+
+        // Read payload
+        byte[] payload = new byte[payloadLength];
+        readFully(in, payload);
+
+        // Unmask if needed
+        if (masked) {
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] ^= maskKey[i % 4];
+            }
+        }
+
+        return new String(payload, StandardCharsets.UTF_8);
+    }
+
+    private static void readFully(InputStream in, byte[] buf) throws IOException {
+        int offset = 0;
+        while (offset < buf.length) {
+            int read = in.read(buf, offset, buf.length - offset);
+            if (read == -1) throw new IOException("Unexpected end of stream (needed " + buf.length + " bytes, got " + offset + ")");
+            offset += read;
+        }
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/handler/IngestBroadcastTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/IngestBroadcastTest.java
@@ -1,0 +1,112 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.EventBroadcaster;
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.cantara.kcp.memory.server.WebSocketFrame;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD test: when events are ingested via POST /ingest/events,
+ * they should be broadcast to the EventBroadcaster.
+ */
+class IngestBroadcastTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private EventBroadcaster broadcaster;
+    private IngestHandler handler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb = Files.createTempFile("kcp-test-", ".db");
+        db = new MemoryDatabase(tempDb);
+        broadcaster = new EventBroadcaster();
+        handler = new IngestHandler(db);
+        handler.setBroadcaster(broadcaster);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    @Test
+    void ingestEventBroadcastsToSubscriber() throws Exception {
+        // Set up a subscriber via piped streams
+        PipedInputStream pipeIn = new PipedInputStream(4096);
+        PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+        broadcaster.subscribe(pipeOut);
+
+        // Build event payload
+        String payload = """
+                {
+                  "events": [
+                    {
+                      "event_ts": "2026-04-12T17:00:00Z",
+                      "tool": "Bash",
+                      "command": "ls -la",
+                      "session_id": "sess-001",
+                      "project_dir": "/src/test",
+                      "source_instance": "laptop"
+                    }
+                  ]
+                }
+                """;
+
+        // Execute POST /ingest/events via real TCP exchange
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    byte[] bodyBytes = payload.getBytes(StandardCharsets.UTF_8);
+                    String request = "POST /ingest/events HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Content-Type: application/json\r\n"
+                            + "Content-Length: " + bodyBytes.length + "\r\n"
+                            + "\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.write(bodyBytes);
+                    out.flush();
+
+                    // Read response
+                    client.getInputStream().readAllBytes();
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+        }
+
+        // Read the broadcast message from the pipe
+        String broadcastedJson = WebSocketFrame.decode(pipeIn);
+
+        JsonNode node = JSON.readTree(broadcastedJson);
+        assertEquals("tool_event", node.get("type").asText());
+        assertEquals("Bash", node.get("tool").asText());
+        assertEquals("ls -la", node.get("command").asText());
+        assertNotNull(node.get("timestamp"));
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/handler/NodesHandlerTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/NodesHandlerTest.java
@@ -1,0 +1,117 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.peer.NodeRegistry;
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for NodesHandler — GET /nodes returns JSON array of connected peers.
+ */
+class NodesHandlerTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private NodeRegistry registry;
+    private NodesHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        registry = new NodeRegistry();
+        handler = new NodesHandler(registry);
+    }
+
+    @Test
+    void emptyRegistryReturnsEmptyArray() throws Exception {
+        String responseBody = executeGetNodes();
+
+        JsonNode json = JSON.readTree(responseBody);
+        assertTrue(json.isArray(), "Response should be a JSON array");
+        assertEquals(0, json.size());
+    }
+
+    @Test
+    void oneRegisteredNodeReturnsOneElementArray() throws Exception {
+        registry.register("laptop", "ssh://user@laptop");
+        registry.updateHealth("laptop", 42, 1337);
+
+        String responseBody = executeGetNodes();
+
+        JsonNode json = JSON.readTree(responseBody);
+        assertTrue(json.isArray());
+        assertEquals(1, json.size());
+
+        JsonNode node = json.get(0);
+        assertEquals("laptop", node.get("peerId").asText());
+        assertEquals("ssh://user@laptop", node.get("address").asText());
+        assertEquals("ok", node.get("status").asText());
+        assertEquals(42, node.get("sessionCount").asInt());
+        assertEquals(1337, node.get("eventCount").asInt());
+        assertNotNull(node.get("lastSeen").asText());
+    }
+
+    @Test
+    void responseIsValidJson() throws Exception {
+        registry.register("node-a", "tcp://a:7735");
+        registry.register("node-b", "tcp://b:7735");
+
+        String responseBody = executeGetNodes();
+
+        // Parse should succeed without exception
+        JsonNode json = JSON.readTree(responseBody);
+        assertTrue(json.isArray());
+        assertEquals(2, json.size());
+
+        // Sorted by peerId
+        assertEquals("node-a", json.get(0).get("peerId").asText());
+        assertEquals("node-b", json.get(1).get("peerId").asText());
+    }
+
+    /**
+     * Helper: create a real TCP exchange via ServerSocket, invoke the handler, capture response.
+     */
+    private String executeGetNodes() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            StringBuilder responseCapture = new StringBuilder();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    String request = "GET /nodes HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    String response = new String(client.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    synchronized (responseCapture) {
+                        responseCapture.append(response);
+                    }
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+
+            String fullResponse;
+            synchronized (responseCapture) {
+                fullResponse = responseCapture.toString();
+            }
+            int bodyStart = fullResponse.indexOf("\r\n\r\n");
+            assertTrue(bodyStart >= 0, "Response should contain HTTP headers");
+            return fullResponse.substring(bodyStart + 4);
+        }
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/handler/WsHandlerTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/WsHandlerTest.java
@@ -1,0 +1,173 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.EventBroadcaster;
+import com.cantara.kcp.memory.server.TcpExchange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for WsHandler — WebSocket upgrade for GET /ws.
+ */
+class WsHandlerTest {
+
+    private EventBroadcaster broadcaster;
+    private WsHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        broadcaster = new EventBroadcaster();
+        handler = new WsHandler(broadcaster);
+    }
+
+    @Test
+    void validWsUpgradeReturns101WithCorrectAccept() throws Exception {
+        // RFC 6455 example: key "dGhlIHNhbXBsZSBub25jZQ==" -> accept "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        String wsKey = "dGhlIHNhbXBsZSBub25jZQ==";
+        String expectedAccept = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            StringBuilder responseCapture = new StringBuilder();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    String request = "GET /ws HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Upgrade: websocket\r\n"
+                            + "Connection: Upgrade\r\n"
+                            + "Sec-WebSocket-Key: " + wsKey + "\r\n"
+                            + "Content-Length: 0\r\n"
+                            + "\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Read the 101 response (read line by line until empty line)
+                    BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(client.getInputStream(), StandardCharsets.UTF_8));
+                    String line;
+                    while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                        synchronized (responseCapture) {
+                            responseCapture.append(line).append("\n");
+                        }
+                    }
+                    // Close to trigger handler's IOException and unblock
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+
+            String response;
+            synchronized (responseCapture) {
+                response = responseCapture.toString();
+            }
+
+            assertTrue(response.contains("101 Switching Protocols"), "Should return 101");
+            assertTrue(response.contains("Upgrade: websocket"), "Should contain Upgrade header");
+            assertTrue(response.contains("Connection: Upgrade"), "Should contain Connection header");
+            assertTrue(response.contains("Sec-WebSocket-Accept: " + expectedAccept),
+                    "Should contain correct Sec-WebSocket-Accept: got:\n" + response);
+        }
+    }
+
+    @Test
+    void missingWebSocketKeyReturns400() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            StringBuilder responseCapture = new StringBuilder();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    // Missing Sec-WebSocket-Key header
+                    String request = "GET /ws HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Content-Length: 0\r\n"
+                            + "\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    String response = new String(client.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    synchronized (responseCapture) {
+                        responseCapture.append(response);
+                    }
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+
+            String response;
+            synchronized (responseCapture) {
+                response = responseCapture.toString();
+            }
+
+            assertTrue(response.contains("400 Bad Request"),
+                    "Should return 400 when Sec-WebSocket-Key is missing");
+        }
+    }
+
+    @Test
+    void clientSubscribesToBroadcasterAfterUpgrade() throws Exception {
+        assertEquals(0, broadcaster.subscriberCount());
+
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    String request = "GET /ws HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Upgrade: websocket\r\n"
+                            + "Connection: Upgrade\r\n"
+                            + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                            + "Content-Length: 0\r\n"
+                            + "\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    // Keep connection alive briefly, then close to trigger handler exit
+                    Thread.sleep(200);
+                } catch (Exception ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+
+            // Run handle() in a virtual thread (it blocks reading frames)
+            Thread handlerThread = Thread.ofVirtual().start(() -> {
+                try (TcpExchange ex = new TcpExchange(serverSide)) {
+                    handler.handle(ex);
+                } catch (IOException ignored) {}
+            });
+
+            // Wait for the handler to subscribe
+            Thread.sleep(100);
+            assertEquals(1, broadcaster.subscriberCount(),
+                    "Client should be subscribed to broadcaster");
+
+            // Wait for client to close, triggering unsubscribe
+            clientThread.join(2000);
+            handlerThread.join(2000);
+
+            assertEquals(0, broadcaster.subscriberCount(),
+                    "Client should be unsubscribed after disconnect");
+        }
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/peer/NodeRegistryTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/peer/NodeRegistryTest.java
@@ -1,0 +1,142 @@
+package com.cantara.kcp.memory.peer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for NodeRegistry — thread-safe registry of connected peer nodes.
+ */
+class NodeRegistryTest {
+
+    private NodeRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new NodeRegistry();
+    }
+
+    @Test
+    void registerAndListReturnsOneNode() {
+        registry.register("laptop", "ssh://user@laptop");
+
+        List<NodeRegistry.NodeInfo> nodes = registry.list();
+        assertEquals(1, nodes.size());
+
+        NodeRegistry.NodeInfo node = nodes.get(0);
+        assertEquals("laptop", node.peerId());
+        assertEquals("ssh://user@laptop", node.address());
+        assertEquals("ok", node.status());
+        assertEquals(0, node.sessionCount());
+        assertEquals(0, node.eventCount());
+        assertNotNull(node.lastSeen());
+    }
+
+    @Test
+    void updateHealthReflectsNewCounts() {
+        registry.register("server-a", "tcp://10.0.0.1:7735");
+        registry.updateHealth("server-a", 42, 1337);
+
+        List<NodeRegistry.NodeInfo> nodes = registry.list();
+        assertEquals(1, nodes.size());
+        assertEquals(42, nodes.get(0).sessionCount());
+        assertEquals(1337, nodes.get(0).eventCount());
+    }
+
+    @Test
+    void markSeenUpdatesLastSeen() throws InterruptedException {
+        registry.register("node-1", "tcp://host:1234");
+
+        Instant firstSeen = registry.list().get(0).lastSeen();
+        Thread.sleep(10); // small delay to ensure timestamp difference
+        registry.markSeen("node-1");
+        Instant afterMarkSeen = registry.list().get(0).lastSeen();
+
+        assertTrue(afterMarkSeen.isAfter(firstSeen) || afterMarkSeen.equals(firstSeen),
+                "lastSeen should be updated after markSeen");
+    }
+
+    @Test
+    void removeRemovesTheNode() {
+        registry.register("to-remove", "tcp://host:9999");
+        assertEquals(1, registry.list().size());
+
+        registry.remove("to-remove");
+        assertEquals(0, registry.list().size());
+    }
+
+    @Test
+    void isStaleReturnsTrueWhenLastSeenOlderThanThreshold() throws InterruptedException {
+        registry.register("stale-node", "tcp://host:5555");
+        // Wait briefly so the node's lastSeen is in the past
+        Thread.sleep(50);
+
+        assertTrue(registry.isStale("stale-node", Duration.ofMillis(10)),
+                "Node should be stale after threshold");
+        assertFalse(registry.isStale("stale-node", Duration.ofSeconds(60)),
+                "Node should not be stale within generous threshold");
+    }
+
+    @Test
+    void isStaleReturnsFalseForUnknownNode() {
+        assertFalse(registry.isStale("nonexistent", Duration.ofMillis(1)));
+    }
+
+    @Test
+    void listSortedByPeerIdAlphabetically() {
+        registry.register("charlie", "tcp://c:1");
+        registry.register("alpha", "tcp://a:1");
+        registry.register("bravo", "tcp://b:1");
+
+        List<NodeRegistry.NodeInfo> nodes = registry.list();
+        assertEquals(3, nodes.size());
+        assertEquals("alpha", nodes.get(0).peerId());
+        assertEquals("bravo", nodes.get(1).peerId());
+        assertEquals("charlie", nodes.get(2).peerId());
+    }
+
+    @Test
+    void concurrentRegisterAndListIsThreadSafe() throws InterruptedException {
+        int threadCount = 100;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final String peerId = "peer-" + i;
+            Thread.ofVirtual().start(() -> {
+                try {
+                    registry.register(peerId, "tcp://" + peerId + ":7735");
+                    registry.list(); // concurrent read
+                    registry.markSeen(peerId);
+                    registry.list(); // another concurrent read
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        assertEquals(0, errors.get(), "No exceptions should occur during concurrent access");
+        assertEquals(threadCount, registry.list().size());
+    }
+
+    @Test
+    void registerSamePeerIdUpdatesAddress() {
+        registry.register("node-x", "tcp://old:1234");
+        registry.register("node-x", "tcp://new:5678");
+
+        List<NodeRegistry.NodeInfo> nodes = registry.list();
+        assertEquals(1, nodes.size());
+        assertEquals("tcp://new:5678", nodes.get(0).address());
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/server/EventBroadcasterTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/server/EventBroadcasterTest.java
@@ -1,0 +1,115 @@
+package com.cantara.kcp.memory.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for EventBroadcaster — fan-out of JSON events to WebSocket subscribers.
+ */
+class EventBroadcasterTest {
+
+    private EventBroadcaster broadcaster;
+
+    @BeforeEach
+    void setUp() {
+        broadcaster = new EventBroadcaster();
+    }
+
+    @Test
+    void broadcastToZeroSubscribersDoesNotThrow() {
+        assertDoesNotThrow(() -> broadcaster.broadcast("{\"type\":\"test\"}"));
+    }
+
+    @Test
+    void broadcastDeliversMessageToOneSubscriber() throws IOException {
+        PipedInputStream pipeIn = new PipedInputStream();
+        PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+
+        broadcaster.subscribe(pipeOut);
+        assertEquals(1, broadcaster.subscriberCount());
+
+        broadcaster.broadcast("{\"event\":\"hello\"}");
+
+        // Read the WebSocket frame from the pipe
+        String received = WebSocketFrame.decode(pipeIn);
+        assertEquals("{\"event\":\"hello\"}", received);
+    }
+
+    @Test
+    void broadcastDeliversToMultipleSubscribers() throws IOException {
+        PipedInputStream pipeIn1 = new PipedInputStream();
+        PipedOutputStream pipeOut1 = new PipedOutputStream(pipeIn1);
+        PipedInputStream pipeIn2 = new PipedInputStream();
+        PipedOutputStream pipeOut2 = new PipedOutputStream(pipeIn2);
+
+        broadcaster.subscribe(pipeOut1);
+        broadcaster.subscribe(pipeOut2);
+        assertEquals(2, broadcaster.subscriberCount());
+
+        broadcaster.broadcast("{\"event\":\"multi\"}");
+
+        assertEquals("{\"event\":\"multi\"}", WebSocketFrame.decode(pipeIn1));
+        assertEquals("{\"event\":\"multi\"}", WebSocketFrame.decode(pipeIn2));
+    }
+
+    @Test
+    void deadSubscriberIsSilentlyRemovedOnNextBroadcast() throws IOException {
+        PipedInputStream pipeIn = new PipedInputStream();
+        PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
+
+        broadcaster.subscribe(pipeOut);
+        assertEquals(1, broadcaster.subscriberCount());
+
+        // Close the pipe to simulate a dead client
+        pipeIn.close();
+        pipeOut.close();
+
+        // This broadcast should detect the dead subscriber and remove it
+        broadcaster.broadcast("{\"event\":\"after-close\"}");
+        assertEquals(0, broadcaster.subscriberCount());
+    }
+
+    @Test
+    void subscriberCountReturnsCorrectValueAfterOperations() throws IOException {
+        assertEquals(0, broadcaster.subscriberCount());
+
+        PipedInputStream pipeIn1 = new PipedInputStream();
+        PipedOutputStream pipeOut1 = new PipedOutputStream(pipeIn1);
+        PipedInputStream pipeIn2 = new PipedInputStream();
+        PipedOutputStream pipeOut2 = new PipedOutputStream(pipeIn2);
+
+        broadcaster.subscribe(pipeOut1);
+        assertEquals(1, broadcaster.subscriberCount());
+
+        broadcaster.subscribe(pipeOut2);
+        assertEquals(2, broadcaster.subscriberCount());
+
+        broadcaster.unsubscribe(pipeOut1);
+        assertEquals(1, broadcaster.subscriberCount());
+    }
+
+    @Test
+    void unsubscribeRemovesSpecificSubscriber() throws IOException {
+        PipedInputStream pipeIn1 = new PipedInputStream();
+        PipedOutputStream pipeOut1 = new PipedOutputStream(pipeIn1);
+        PipedInputStream pipeIn2 = new PipedInputStream();
+        PipedOutputStream pipeOut2 = new PipedOutputStream(pipeIn2);
+
+        broadcaster.subscribe(pipeOut1);
+        broadcaster.subscribe(pipeOut2);
+        broadcaster.unsubscribe(pipeOut1);
+
+        broadcaster.broadcast("{\"event\":\"only-sub2\"}");
+
+        // sub2 should still receive
+        assertEquals("{\"event\":\"only-sub2\"}", WebSocketFrame.decode(pipeIn2));
+
+        // sub1 pipe should have no data (nothing was written to it after unsubscribe)
+        assertEquals(0, pipeIn1.available());
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/server/WebSocketFrameTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/server/WebSocketFrameTest.java
@@ -1,0 +1,152 @@
+package com.cantara.kcp.memory.server;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for WebSocketFrame RFC 6455 text frame encoder/decoder.
+ */
+class WebSocketFrameTest {
+
+    @Test
+    void roundTripShortMessage() throws IOException {
+        String message = "Hello, WebSocket!";
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void roundTripEmptyMessage() throws IOException {
+        String message = "";
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void roundTripMediumMessage() throws IOException {
+        // 300 bytes — triggers 16-bit extended length (126-65535 range)
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 300; i++) {
+            sb.append((char) ('A' + (i % 26)));
+        }
+        String message = sb.toString();
+        assertEquals(300, message.getBytes(StandardCharsets.UTF_8).length);
+
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void roundTripExactly126Bytes() throws IOException {
+        // Boundary: exactly 126 bytes triggers 16-bit length
+        String message = "A".repeat(126);
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void roundTripExactly125Bytes() throws IOException {
+        // Boundary: 125 bytes uses 7-bit length
+        String message = "B".repeat(125);
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void maskedClientFrameDecode() throws IOException {
+        // Build a masked text frame as a client would send (per RFC 6455)
+        String payload = "Hello";
+        byte[] payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
+
+        ByteArrayOutputStream frame = new ByteArrayOutputStream();
+        frame.write(0x81); // FIN + text opcode
+        frame.write(0x80 | payloadBytes.length); // MASK bit set + 7-bit length
+
+        // Masking key (4 bytes)
+        byte[] maskKey = {0x37, 0x13, (byte) 0xAE, 0x4D};
+        frame.write(maskKey);
+
+        // Masked payload
+        for (int i = 0; i < payloadBytes.length; i++) {
+            frame.write(payloadBytes[i] ^ maskKey[i % 4]);
+        }
+
+        InputStream in = new ByteArrayInputStream(frame.toByteArray());
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(payload, decoded);
+    }
+
+    @Test
+    void maskedClientFrameWith16BitLength() throws IOException {
+        // Masked frame with 16-bit extended length
+        String payload = "X".repeat(200);
+        byte[] payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
+
+        ByteArrayOutputStream frame = new ByteArrayOutputStream();
+        frame.write(0x81); // FIN + text opcode
+        frame.write(0x80 | 126); // MASK bit set + 126 signals 16-bit length
+
+        // 16-bit length (big-endian)
+        frame.write((payloadBytes.length >> 8) & 0xFF);
+        frame.write(payloadBytes.length & 0xFF);
+
+        // Masking key
+        byte[] maskKey = {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+        frame.write(maskKey);
+
+        // Masked payload
+        for (int i = 0; i < payloadBytes.length; i++) {
+            frame.write(payloadBytes[i] ^ maskKey[i % 4]);
+        }
+
+        InputStream in = new ByteArrayInputStream(frame.toByteArray());
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(payload, decoded);
+    }
+
+    @Test
+    void utf8ContentPreserved() throws IOException {
+        // Test with multi-byte UTF-8 characters
+        String message = "Hello \u00e6\u00f8\u00e5 \u2603 \uD83D\uDE00";
+        byte[] encoded = WebSocketFrame.encode(message);
+        InputStream in = new ByteArrayInputStream(encoded);
+        String decoded = WebSocketFrame.decode(in);
+        assertEquals(message, decoded);
+    }
+
+    @Test
+    void serverFrameIsNotMasked() {
+        // Server-to-client frames must NOT have mask bit set
+        String message = "test";
+        byte[] encoded = WebSocketFrame.encode(message);
+        // Second byte: mask bit is the high bit
+        int secondByte = encoded[1] & 0xFF;
+        assertEquals(0, secondByte & 0x80, "Server frames must not be masked");
+    }
+
+    @Test
+    void encodeHasCorrectOpcode() {
+        String message = "test";
+        byte[] encoded = WebSocketFrame.encode(message);
+        // First byte: FIN (0x80) + text opcode (0x01) = 0x81
+        assertEquals((byte) 0x81, encoded[0]);
+    }
+}


### PR DESCRIPTION
## Summary

- **WebSocketFrame**: RFC 6455 text frame encoder/decoder — handles 7-bit and 16-bit payload lengths, masked client frames, and UTF-8 content preservation
- **NodeRegistry**: Thread-safe (`ConcurrentHashMap`) registry of connected peer nodes with health metrics, staleness detection, and sorted listing
- **EventBroadcaster**: Fan-out JSON events to all connected WebSocket clients via `CopyOnWriteArrayList`, with automatic dead-subscriber cleanup
- **NodesHandler** (`GET /nodes`): Returns JSON array of connected peers from the registry
- **WsHandler** (`GET /ws`): WebSocket upgrade handshake with correct `Sec-WebSocket-Accept` computation (verified against RFC 6455 example), subscribes client to EventBroadcaster
- **IngestHandler**: Now broadcasts each ingested event to WebSocket subscribers (null-safe — works without broadcaster)
- **PeerSyncService**: Registers/updates peers in NodeRegistry after each successful sync cycle
- **TcpExchange**: Exposes raw `InputStream` for WebSocket frame reading after HTTP upgrade

## Test plan

- [x] 10 WebSocketFrame tests (round-trip short/medium/boundary, masked decode, UTF-8, opcode/mask verification)
- [x] 9 NodeRegistry tests (register, updateHealth, markSeen, remove, isStale, sorted list, concurrent safety with 100 virtual threads)
- [x] 6 EventBroadcaster tests (zero/one/multi subscribers, dead subscriber removal, subscribe/unsubscribe counts)
- [x] 3 NodesHandler tests (empty registry, one node with correct fields, valid sorted JSON)
- [x] 3 WsHandler tests (valid 101 with RFC 6455 accept value, missing key returns 400, subscriber count lifecycle)
- [x] 1 IngestBroadcast test (POST /ingest/events broadcasts to WebSocket subscriber)
- [x] All 33 original tests still pass (65 total, 0 failures)
- [x] `mvn test` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)