### PR TITLE
feat: /files browser + /process control endpoints

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
+++ b/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
@@ -31,12 +31,15 @@ import java.util.logging.Logger;
  *
  * <p>Endpoints:
  * <pre>
- *   GET  /health          — liveness + session count
- *   GET  /search?q=...    — FTS5 full-text search
- *   GET  /sessions        — list recent sessions
- *   GET  /stats           — aggregate statistics
- *   POST /scan            — trigger incremental scan (fire-and-forget)
- *   GET  /events/search   — tool-call event search
+ *   GET  /health              — liveness + session count
+ *   GET  /search?q=...        — FTS5 full-text search
+ *   GET  /sessions            — list recent sessions
+ *   GET  /stats               — aggregate statistics
+ *   POST /scan                — trigger incremental scan (fire-and-forget)
+ *   GET  /events/search       — tool-call event search
+ *   GET  /files?path=...      — directory listing (dirs-first, sorted)
+ *   GET  /files/content?path= — read file content (max 1MB, UTF-8)
+ *   POST /process             — systemctl action on named service
  * </pre>
  */
 public class KcpMemoryDaemon {
@@ -70,6 +73,14 @@ public class KcpMemoryDaemon {
         server.createContext("/events/search", new EventsHandler(db));
         server.createContext("/ingest",        ingestHandler);
         server.createContext("/nodes",         new NodesHandler(nodeRegistry));
+
+        // File browser (hub-local)
+        FileHandler fileHandler = new FileHandler();
+        server.createContext("/files", fileHandler);
+
+        // Process control (hub-local)
+        ProcessHandler processHandler = new ProcessHandler();
+        server.createContext("/process", processHandler);
 
         server.start();
         LOG.info("kcp-memory daemon started on port " + PORT);
@@ -154,6 +165,10 @@ public class KcpMemoryDaemon {
         // Control plane endpoints
         externalServer.createContext("/nodes", new NodesHandler(nodeRegistry));
         externalServer.createContext("/ws", new WsHandler(broadcaster));
+
+        // File browser + process control (hub-local, available externally)
+        externalServer.createContext("/files", new FileHandler());
+        externalServer.createContext("/process", new ProcessHandler());
 
         // Mobile-specific endpoints
         externalServer.createContext("/dispatch", new DispatchHandler());

--- a/java/src/main/java/com/cantara/kcp/memory/handler/FileHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/FileHandler.java
@@ -1,0 +1,178 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+
+import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * GET /files — directory listing (hub-local, dirs-first sorted, path traversal protected).
+ * GET /files/content — read file content (max 1MB, UTF-8 only).
+ *
+ * <p>Security: all paths are validated against {@code allowedRoot}. Path traversal
+ * attempts (e.g. {@code ../../etc/passwd}) are rejected with HTTP 400.
+ *
+ * <h3>Android client reference</h3>
+ * <ul>
+ *   <li>{@code GET /files?path=...} &rarr; parse JSON to {@code FileListResponse(path, entries)}</li>
+ *   <li>{@code GET /files/content?path=...} &rarr; String (raw text)</li>
+ * </ul>
+ */
+public class FileHandler extends BaseHandler {
+
+    private static final long MAX_FILE_SIZE = 1024 * 1024; // 1 MB
+    private static final DateTimeFormatter ISO = DateTimeFormatter.ISO_INSTANT;
+
+    private final Path allowedRoot;
+
+    public FileHandler() {
+        this(Path.of(System.getProperty("user.home")));
+    }
+
+    public FileHandler(Path allowedRoot) {
+        this.allowedRoot = allowedRoot.toAbsolutePath().normalize();
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        String uriPath = ex.getRequestURI().getPath();
+
+        if (uriPath.endsWith("/content")) {
+            handleContent(ex);
+        } else {
+            handleList(ex);
+        }
+    }
+
+    private void handleList(TcpExchange ex) throws IOException {
+        Map<String, String> params = queryParams(ex);
+        String pathParam = params.get("path");
+
+        Path target;
+        try {
+            target = resolveSafe(pathParam);
+        } catch (SecurityException e) {
+            sendError(ex, 400, e.getMessage());
+            return;
+        }
+
+        if (!Files.exists(target)) {
+            sendError(ex, 404, "Path not found: " + target);
+            return;
+        }
+
+        if (!Files.isDirectory(target)) {
+            sendError(ex, 400, "Path is a file, not a directory. Use /files/content to read files.");
+            return;
+        }
+
+        List<Map<String, Object>> entries = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(target)) {
+            List<Path> children = stream.sorted(Comparator.comparing(Path::getFileName)).toList();
+
+            // Separate dirs and files, then merge (dirs first)
+            List<Path> dirs = new ArrayList<>();
+            List<Path> files = new ArrayList<>();
+            for (Path child : children) {
+                if (Files.isDirectory(child)) {
+                    dirs.add(child);
+                } else {
+                    files.add(child);
+                }
+            }
+
+            for (Path dir : dirs) {
+                entries.add(entryMap(dir, "dir"));
+            }
+            for (Path file : files) {
+                entries.add(entryMap(file, "file"));
+            }
+        }
+
+        sendJson(ex, 200, Map.of(
+                "path", target.toString(),
+                "entries", entries
+        ));
+    }
+
+    private void handleContent(TcpExchange ex) throws IOException {
+        Map<String, String> params = queryParams(ex);
+        String pathParam = params.get("path");
+
+        Path target;
+        try {
+            target = resolveSafe(pathParam);
+        } catch (SecurityException e) {
+            sendError(ex, 400, e.getMessage());
+            return;
+        }
+
+        if (!Files.exists(target)) {
+            sendError(ex, 404, "File not found: " + target);
+            return;
+        }
+
+        if (Files.isDirectory(target)) {
+            sendError(ex, 400, "Path is a directory. Use /files to list directories.");
+            return;
+        }
+
+        long size = Files.size(target);
+        if (size > MAX_FILE_SIZE) {
+            sendError(ex, 400, "File too large (" + size + " bytes). Maximum is " + MAX_FILE_SIZE + " bytes.");
+            return;
+        }
+
+        // Read raw bytes and check if valid UTF-8
+        byte[] raw = Files.readAllBytes(target);
+        String content;
+        try {
+            content = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(raw))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            sendError(ex, 400, "Binary file — not viewable");
+            return;
+        }
+
+        ex.sendResponse(200, "text/plain; charset=utf-8", content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Resolve path parameter safely within allowedRoot.
+     *
+     * @param pathParam the path query parameter (may be null for default)
+     * @return resolved and validated absolute path
+     * @throws SecurityException if path traversal is detected
+     */
+    private Path resolveSafe(String pathParam) throws SecurityException {
+        if (pathParam == null || pathParam.isBlank()) {
+            return allowedRoot;
+        }
+
+        Path resolved = Path.of(pathParam).toAbsolutePath().normalize();
+        if (!resolved.startsWith(allowedRoot)) {
+            throw new SecurityException("Access denied — path outside allowed root");
+        }
+        return resolved;
+    }
+
+    private Map<String, Object> entryMap(Path path, String type) throws IOException {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("name", path.getFileName().toString());
+        map.put("type", type);
+        map.put("size", "dir".equals(type) ? 0L : Files.size(path));
+        map.put("modified", ISO.format(Files.getLastModifiedTime(path).toInstant()));
+        return map;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/handler/ProcessHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/ProcessHandler.java
@@ -1,0 +1,132 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * POST /process — run systemctl actions on named services.
+ *
+ * <p>Security constraints:
+ * <ul>
+ *   <li>Only alphanumeric service names (plus {@code -}, {@code _}, {@code .})</li>
+ *   <li>Only allowed actions: status, start, stop, restart</li>
+ *   <li>Returns 503 if systemctl is not available</li>
+ * </ul>
+ *
+ * <h3>Android client reference</h3>
+ * <p>{@code POST /process} body JSON &rarr; {@code ProcessResponse(service, action, output)}</p>
+ */
+public class ProcessHandler extends BaseHandler {
+
+    private static final Logger LOG = Logger.getLogger(ProcessHandler.class.getName());
+    private static final Pattern SAFE_SERVICE = Pattern.compile("[a-zA-Z0-9._-]+");
+    private static final Set<String> ALLOWED_ACTIONS = Set.of("status", "start", "stop", "restart");
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        if (!"POST".equalsIgnoreCase(ex.getRequestMethod())) {
+            sendError(ex, 405, "Method not allowed");
+            return;
+        }
+
+        if (!isSystemctlAvailable()) {
+            sendError(ex, 503, "systemctl not available");
+            return;
+        }
+
+        String body = readBody(ex);
+        if (body == null || body.isBlank()) {
+            sendError(ex, 400, "Request body is required");
+            return;
+        }
+
+        JsonNode json;
+        try {
+            json = MAPPER.readTree(body);
+        } catch (Exception e) {
+            sendError(ex, 400, "Invalid JSON: " + e.getMessage());
+            return;
+        }
+
+        String action = json.path("action").asText(null);
+        String service = json.path("service").asText(null);
+
+        if (action == null || action.isBlank()) {
+            sendError(ex, 400, "Missing required field: action");
+            return;
+        }
+        if (service == null || service.isBlank()) {
+            sendError(ex, 400, "Missing required field: service");
+            return;
+        }
+
+        if (!ALLOWED_ACTIONS.contains(action)) {
+            sendError(ex, 400, "Invalid action: " + action + ". Allowed: " + ALLOWED_ACTIONS);
+            return;
+        }
+
+        if (!SAFE_SERVICE.matcher(service).matches()) {
+            sendError(ex, 400, "Invalid service name: " + service);
+            return;
+        }
+
+        try {
+            String output = runSystemctl(action, service);
+            sendJson(ex, 200, Map.of(
+                    "service", service,
+                    "action", action,
+                    "output", output
+            ));
+        } catch (IOException e) {
+            LOG.warning("systemctl failed: " + e.getMessage());
+            sendError(ex, 500, "systemctl failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Run systemctl with the given action and service.
+     * Package-private for testability (override in tests).
+     */
+    String runSystemctl(String action, String service) throws IOException {
+        ProcessBuilder pb = new ProcessBuilder("systemctl", action, service);
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        String output;
+        try {
+            output = new String(process.getInputStream().readAllBytes());
+            boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new IOException("systemctl timed out after 10 seconds");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("systemctl interrupted", e);
+        }
+
+        return output;
+    }
+
+    /**
+     * Check if systemctl is available on this system.
+     * Package-private for testability (override in tests).
+     */
+    boolean isSystemctlAvailable() {
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (!os.contains("linux")) {
+            return false;
+        }
+        return Files.isExecutable(Path.of("/usr/bin/systemctl"))
+                || Files.isExecutable(Path.of("/bin/systemctl"));
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
+++ b/java/src/main/java/com/cantara/kcp/memory/server/TcpExchange.java
@@ -19,18 +19,20 @@ import java.util.Map;
  */
 public class TcpExchange implements Closeable {
 
-    private static final Map<Integer, String> STATUS_TEXT = new HashMap<>(Map.of(
-            200, "OK",
-            201, "Created",
-            202, "Accepted",
-            204, "No Content",
-            400, "Bad Request",
-            401, "Unauthorized",
-            404, "Not Found",
-            405, "Method Not Allowed",
-            500, "Internal Server Error",
-            502, "Bad Gateway"
-    ));
+    private static final Map<Integer, String> STATUS_TEXT = new HashMap<>();
+    static {
+        STATUS_TEXT.put(200, "OK");
+        STATUS_TEXT.put(201, "Created");
+        STATUS_TEXT.put(202, "Accepted");
+        STATUS_TEXT.put(204, "No Content");
+        STATUS_TEXT.put(400, "Bad Request");
+        STATUS_TEXT.put(401, "Unauthorized");
+        STATUS_TEXT.put(404, "Not Found");
+        STATUS_TEXT.put(405, "Method Not Allowed");
+        STATUS_TEXT.put(500, "Internal Server Error");
+        STATUS_TEXT.put(502, "Bad Gateway");
+        STATUS_TEXT.put(503, "Service Unavailable");
+    }
 
     private final Socket socket;
     private final InputStream in;

--- a/java/src/test/java/com/cantara/kcp/memory/handler/FileHandlerTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/FileHandlerTest.java
@@ -1,0 +1,261 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for FileHandler — GET /files (dir listing) + GET /files/content (file read).
+ */
+class FileHandlerTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private Path tempDir;
+    private FileHandler handler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("kcp-file-test-");
+        handler = new FileHandler(tempDir);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (tempDir != null && Files.exists(tempDir)) {
+            Files.walk(tempDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                    });
+        }
+    }
+
+    // ---- GET /files — directory listing ----
+
+    @Test
+    void listEmptyDirReturnsEmptyEntries() throws Exception {
+        String body = requestBody("GET /files?path=" + tempDir + " HTTP/1.1");
+
+        JsonNode json = JSON.readTree(body);
+        assertEquals(tempDir.toString(), json.get("path").asText());
+        assertTrue(json.get("entries").isArray());
+        assertEquals(0, json.get("entries").size());
+    }
+
+    @Test
+    void listDirReturnsDirsBeforeFiles() throws Exception {
+        Files.writeString(tempDir.resolve("alpha.txt"), "hello");
+        Files.createDirectory(tempDir.resolve("zulu-dir"));
+
+        String body = requestBody("GET /files?path=" + tempDir + " HTTP/1.1");
+
+        JsonNode entries = JSON.readTree(body).get("entries");
+        assertEquals(2, entries.size());
+        // Dir first, then file
+        assertEquals("dir", entries.get(0).get("type").asText());
+        assertEquals("zulu-dir", entries.get(0).get("name").asText());
+        assertEquals("file", entries.get(1).get("type").asText());
+        assertEquals("alpha.txt", entries.get(1).get("name").asText());
+    }
+
+    @Test
+    void listDirSortsAlphabetically() throws Exception {
+        Files.createDirectory(tempDir.resolve("beta-dir"));
+        Files.createDirectory(tempDir.resolve("alpha-dir"));
+        Files.writeString(tempDir.resolve("charlie.txt"), "c");
+        Files.writeString(tempDir.resolve("bravo.txt"), "b");
+
+        String body = requestBody("GET /files?path=" + tempDir + " HTTP/1.1");
+
+        JsonNode entries = JSON.readTree(body).get("entries");
+        assertEquals(4, entries.size());
+        // Dirs first, alphabetical
+        assertEquals("alpha-dir", entries.get(0).get("name").asText());
+        assertEquals("beta-dir", entries.get(1).get("name").asText());
+        // Files next, alphabetical
+        assertEquals("bravo.txt", entries.get(2).get("name").asText());
+        assertEquals("charlie.txt", entries.get(3).get("name").asText());
+    }
+
+    @Test
+    void listDirIncludesFileSize() throws Exception {
+        Files.writeString(tempDir.resolve("sized.txt"), "12345");
+
+        String body = requestBody("GET /files?path=" + tempDir + " HTTP/1.1");
+
+        JsonNode entry = JSON.readTree(body).get("entries").get(0);
+        assertEquals("sized.txt", entry.get("name").asText());
+        assertTrue(entry.get("size").asLong() > 0);
+    }
+
+    @Test
+    void listDirIncludesModifiedTimestamp() throws Exception {
+        Files.writeString(tempDir.resolve("ts.txt"), "time");
+
+        String body = requestBody("GET /files?path=" + tempDir + " HTTP/1.1");
+
+        JsonNode entry = JSON.readTree(body).get("entries").get(0);
+        assertNotNull(entry.get("modified"));
+        // ISO-8601 format contains "T"
+        assertTrue(entry.get("modified").asText().contains("T"));
+    }
+
+    @Test
+    void listNonExistentPathReturns404() throws Exception {
+        String resp = request("GET /files?path=" + tempDir + "/no-such-dir HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 404"), "Expected 404, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void listFilePathReturns400() throws Exception {
+        Files.writeString(tempDir.resolve("afile.txt"), "data");
+
+        String resp = request("GET /files?path=" + tempDir + "/afile.txt HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void pathTraversalBlocked() throws Exception {
+        String resp = request("GET /files?path=" + tempDir + "/../../etc/passwd HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void defaultPathWhenNoPathParam() throws Exception {
+        // When no path param is given, should list the allowed root
+        String body = requestBody("GET /files HTTP/1.1");
+
+        JsonNode json = JSON.readTree(body);
+        assertEquals(tempDir.toString(), json.get("path").asText());
+    }
+
+    // ---- GET /files/content — file reading ----
+
+    @Test
+    void readFileReturnsContent() throws Exception {
+        Files.writeString(tempDir.resolve("hello.txt"), "Hello, world!");
+
+        String resp = request("GET /files/content?path=" + tempDir + "/hello.txt HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 200"), "Expected 200, got: " + resp.lines().findFirst().orElse(""));
+        assertTrue(resp.contains("Hello, world!"));
+    }
+
+    @Test
+    void readFileTooLargeReturns400() throws Exception {
+        // Create a file > 1MB
+        byte[] big = new byte[1024 * 1024 + 1];
+        Files.write(tempDir.resolve("big.bin"), big);
+
+        String resp = request("GET /files/content?path=" + tempDir + "/big.bin HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void readDirAsContentReturns400() throws Exception {
+        Files.createDirectory(tempDir.resolve("subdir"));
+
+        String resp = request("GET /files/content?path=" + tempDir + "/subdir HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void readNonExistentFileReturns404() throws Exception {
+        String resp = request("GET /files/content?path=" + tempDir + "/ghost.txt HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 404"), "Expected 404, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void readContentPathTraversalBlocked() throws Exception {
+        String resp = request("GET /files/content?path=" + tempDir + "/../../etc/passwd HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+    }
+
+    @Test
+    void readBinaryFileReturns400() throws Exception {
+        // Write bytes that are not valid UTF-8
+        byte[] binary = new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}; // PNG header
+        Files.write(tempDir.resolve("image.png"), binary);
+
+        String resp = request("GET /files/content?path=" + tempDir + "/image.png HTTP/1.1");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + resp.lines().findFirst().orElse(""));
+        assertTrue(resp.contains("Binary file"));
+    }
+
+    @Test
+    void defaultPathIsUserHome() {
+        FileHandler defaultHandler = new FileHandler();
+        // The constructor should set allowedRoot to user.home
+        // We can only test that it doesn't throw
+        assertNotNull(defaultHandler);
+    }
+
+    // ---- Test helpers ----
+
+    /**
+     * Send an HTTP request through a real TcpExchange and return the full response string.
+     */
+    private String request(String requestLine) throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            StringBuilder responseCapture = new StringBuilder();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    String httpRequest = requestLine + "\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+                    out.write(httpRequest.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+
+                    String response = new String(client.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    synchronized (responseCapture) {
+                        responseCapture.append(response);
+                    }
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+
+            synchronized (responseCapture) {
+                return responseCapture.toString();
+            }
+        }
+    }
+
+    /**
+     * Send request and return only the body (after HTTP headers).
+     */
+    private String requestBody(String requestLine) throws Exception {
+        String fullResponse = request(requestLine);
+        int bodyStart = fullResponse.indexOf("\r\n\r\n");
+        assertTrue(bodyStart >= 0, "Response should contain HTTP headers");
+        return fullResponse.substring(bodyStart + 4);
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/handler/ProcessHandlerTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/ProcessHandlerTest.java
@@ -1,0 +1,204 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for ProcessHandler — POST /process (systemctl wrapper).
+ *
+ * <p>Uses a testable subclass that overrides runSystemctl() to avoid
+ * actually executing system commands during tests.
+ */
+class ProcessHandlerTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** Captured args from the last runSystemctl call */
+    private String capturedAction;
+    private String capturedService;
+    private String cannedOutput = "Active: active (running)";
+    private boolean systemctlAvailable = true;
+
+    private ProcessHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        capturedAction = null;
+        capturedService = null;
+
+        handler = new ProcessHandler() {
+            @Override
+            String runSystemctl(String action, String service) throws IOException {
+                if (!systemctlAvailable) {
+                    throw new IOException("systemctl not available");
+                }
+                capturedAction = action;
+                capturedService = service;
+                return cannedOutput;
+            }
+
+            @Override
+            boolean isSystemctlAvailable() {
+                return systemctlAvailable;
+            }
+        };
+    }
+
+    @Test
+    void invalidActionReturns400() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"destroy\",\"service\":\"kcp-memory\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+        assertTrue(resp.contains("Invalid action"));
+    }
+
+    @Test
+    void unsafeServiceNameReturns400() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"status\",\"service\":\"../etc/passwd\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+        assertTrue(resp.contains("Invalid service name"));
+    }
+
+    @Test
+    void serviceNameWithSpacesReturns400() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"status\",\"service\":\"rm -rf /\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+    }
+
+    @Test
+    void getMethodReturns405() throws Exception {
+        String resp = request("GET", "/process", "");
+
+        assertTrue(resp.startsWith("HTTP/1.1 405"), "Expected 405, got: " + firstLine(resp));
+    }
+
+    @Test
+    void validRequestCallsSystemctl() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"status\",\"service\":\"kcp-memory\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 200"), "Expected 200, got: " + firstLine(resp));
+        assertEquals("status", capturedAction);
+        assertEquals("kcp-memory", capturedService);
+    }
+
+    @Test
+    void systemctlOutputReturnedInJson() throws Exception {
+        cannedOutput = "Active: active (running) since Mon 2026-04-13";
+
+        String body = requestBody("POST", "/process", "{\"action\":\"restart\",\"service\":\"synthesis\"}");
+
+        JsonNode json = JSON.readTree(body);
+        assertEquals("synthesis", json.get("service").asText());
+        assertEquals("restart", json.get("action").asText());
+        assertEquals(cannedOutput, json.get("output").asText());
+    }
+
+    @Test
+    void systemctlNotAvailableReturns503() throws Exception {
+        systemctlAvailable = false;
+
+        String resp = request("POST", "/process", "{\"action\":\"status\",\"service\":\"kcp-memory\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 503"), "Expected 503, got: " + firstLine(resp));
+        assertTrue(resp.contains("systemctl not available"));
+    }
+
+    @Test
+    void missingActionFieldReturns400() throws Exception {
+        String resp = request("POST", "/process", "{\"service\":\"kcp-memory\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+    }
+
+    @Test
+    void missingServiceFieldReturns400() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"status\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+    }
+
+    @Test
+    void emptyBodyReturns400() throws Exception {
+        String resp = request("POST", "/process", "");
+
+        assertTrue(resp.startsWith("HTTP/1.1 400"), "Expected 400, got: " + firstLine(resp));
+    }
+
+    @Test
+    void serviceWithDotsAndUnderscoresAllowed() throws Exception {
+        String resp = request("POST", "/process", "{\"action\":\"status\",\"service\":\"my_app.service\"}");
+
+        assertTrue(resp.startsWith("HTTP/1.1 200"), "Expected 200, got: " + firstLine(resp));
+        assertEquals("my_app.service", capturedService);
+    }
+
+    // ---- Test helpers ----
+
+    private String request(String method, String path, String body) throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            StringBuilder responseCapture = new StringBuilder();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    StringBuilder req = new StringBuilder();
+                    req.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+                    req.append("Host: localhost\r\n");
+                    if (body != null && !body.isEmpty()) {
+                        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+                        req.append("Content-Length: ").append(bodyBytes.length).append("\r\n");
+                        req.append("Content-Type: application/json\r\n");
+                        req.append("\r\n");
+                        out.write(req.toString().getBytes(StandardCharsets.UTF_8));
+                        out.write(bodyBytes);
+                    } else {
+                        req.append("Content-Length: 0\r\n");
+                        req.append("\r\n");
+                        out.write(req.toString().getBytes(StandardCharsets.UTF_8));
+                    }
+                    out.flush();
+
+                    String response = new String(client.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    synchronized (responseCapture) {
+                        responseCapture.append(response);
+                    }
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+
+            clientThread.join(2000);
+
+            synchronized (responseCapture) {
+                return responseCapture.toString();
+            }
+        }
+    }
+
+    private String requestBody(String method, String path, String body) throws Exception {
+        String fullResponse = request(method, path, body);
+        int bodyStart = fullResponse.indexOf("\r\n\r\n");
+        assertTrue(bodyStart >= 0, "Response should contain HTTP headers");
+        return fullResponse.substring(bodyStart + 4);
+    }
+
+    private String firstLine(String response) {
+        return response.lines().findFirst().orElse("");
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /files?path=` — directory listing (hub-local, dirs-first, path traversal protected)
- `GET /files/content?path=` — file content (max 1MB, UTF-8 only)
- `POST /process` — systemctl action on named service (allowlist validation)
- TDD: all new functionality covered by tests (27 new tests, 92 total)

## Test plan
- [x] `mvn test` passes (65 existing + 27 new = 92 total)
- [x] Path traversal blocked (../../etc/passwd → 400)
- [x] Binary file → 400 with error message
- [x] Invalid service name → 400
- [x] File > 1MB → 400
- [x] Directory listing sorted dirs-first, alphabetical
- [x] systemctl unavailable → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)