### PR TITLE
fix: session prefix lookup (#33) + FTS5 hyphen crash (#34)

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -364,7 +364,7 @@ public class McpServer {
         String sessionId = args.path("session_id").asText("").strip();
         if (sessionId.isEmpty()) return "Error: session_id is required";
 
-        Session s = new SessionStore(db).getById(sessionId);
+        Session s = new SessionStore(db).getByIdOrPrefix(sessionId);
         UsageLogger.logGet(sessionId);
         if (s == null) return "Session not found: " + sessionId;
 
@@ -471,8 +471,9 @@ public class McpServer {
         // Refresh agent index
         new AgentSessionScanner(db).scan(false);
 
-        Session            parent = new SessionStore(db).getById(sessionId);
-        List<AgentSession> agents = new AgentSessionStore(db).listByParent(sessionId, 100);
+        Session            parent     = new SessionStore(db).getByIdOrPrefix(sessionId);
+        String             resolvedId = parent != null ? parent.getSessionId() : sessionId;
+        List<AgentSession> agents = new AgentSessionStore(db).listByParent(resolvedId, 100);
 
         StringBuilder sb = new StringBuilder();
 

--- a/java/src/main/java/com/cantara/kcp/memory/store/EventStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/EventStore.java
@@ -51,7 +51,7 @@ public class EventStore {
                 """;
         List<ToolEvent> results = new ArrayList<>();
         try (PreparedStatement ps = db.getConnection().prepareStatement(sql)) {
-            ps.setString(1, query);
+            ps.setString(1, toFtsQuery(query));
             ps.setInt(2, limit);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) results.add(mapRow(rs));
@@ -125,6 +125,23 @@ public class EventStore {
             ps.setString(3, command);
             ps.executeUpdate();
         }
+    }
+
+    /**
+     * Quote each token so user input is treated as literal text by FTS5.
+     * Prevents characters like '-' from being interpreted as column operators.
+     */
+    private String toFtsQuery(String query) {
+        if (query == null || query.isBlank()) return "\"\"";
+        StringBuilder out = new StringBuilder();
+        for (String token : query.trim().split("\\s+")) {
+            if (token.isBlank()) continue;
+            if (!out.isEmpty()) out.append(' ');
+            out.append('"')
+               .append(token.replace("\"", "\"\""))
+               .append('"');
+        }
+        return out.isEmpty() ? "\"\"" : out.toString();
     }
 
     private ToolEvent mapRow(ResultSet rs) throws SQLException {

--- a/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
@@ -105,6 +105,47 @@ public class SessionStore {
         }
     }
 
+    /**
+     * Return session by exact ID, falling back to a prefix match for the
+     * 8-char short IDs that list/search formatters display.
+     * Returns null if not found, or if the prefix matches multiple sessions (ambiguous).
+     */
+    public Session getByIdOrPrefix(String sessionId) throws SQLException {
+        Session exact = getById(sessionId);
+        if (exact != null) return exact;
+        if (sessionId == null || sessionId.length() >= 36) return null;
+
+        String sql = """
+                SELECT session_id, project_dir, git_branch, slug, model,
+                       started_at, ended_at, turn_count, tool_call_count,
+                       tool_names, files_json, first_message, all_user_text
+                FROM sessions WHERE session_id LIKE ?
+                LIMIT 2
+                """;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, sessionId + "%");
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return null;
+                Session s = new Session();
+                s.setSessionId(rs.getString("session_id"));
+                s.setProjectDir(rs.getString("project_dir"));
+                s.setGitBranch(rs.getString("git_branch"));
+                s.setSlug(rs.getString("slug"));
+                s.setModel(rs.getString("model"));
+                s.setStartedAt(rs.getString("started_at"));
+                s.setEndedAt(rs.getString("ended_at"));
+                s.setTurnCount(rs.getInt("turn_count"));
+                s.setToolCallCount(rs.getInt("tool_call_count"));
+                s.setFirstMessage(rs.getString("first_message"));
+                s.setAllUserText(rs.getString("all_user_text"));
+                s.setToolNames(fromJson(rs.getString("tool_names")));
+                s.setFiles(fromJson(rs.getString("files_json")));
+                if (rs.next()) return null; // ambiguous prefix — multiple matches
+                return s;
+            }
+        }
+    }
+
     /** Return the scanned_at timestamp for a session_id, or null if not indexed. */
     public String getScannedAt(String sessionId) throws SQLException {
         String sql = "SELECT scanned_at FROM sessions WHERE session_id = ?";

--- a/java/src/test/java/com/cantara/kcp/memory/store/EventStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/EventStoreTest.java
@@ -1,0 +1,84 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.ToolEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventStoreTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private EventStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb = Files.createTempFile("kcp-event-test-", ".db");
+        db     = new MemoryDatabase(tempDb);
+        store  = new EventStore(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    @Test
+    void searchFindsExactCommand() throws SQLException {
+        store.insert(makeEvent("kubectl apply -f deploy.yaml"));
+        List<ToolEvent> results = store.search("kubectl", 10);
+        assertFalse(results.isEmpty());
+        assertTrue(results.get(0).command().contains("kubectl"));
+    }
+
+    @Test
+    void searchWithHyphenatedQueryDoesNotThrow() throws SQLException {
+        store.insert(makeEvent("docker build -t my-service:latest ."));
+        // Before fix: FTS5 would throw [SQLITE_ERROR] no such column: service
+        assertDoesNotThrow(() -> store.search("my-service", 10));
+    }
+
+    @Test
+    void searchWithHyphenatedQueryFindsMatches() throws SQLException {
+        store.insert(makeEvent("docker build -t my-service:latest ."));
+        List<ToolEvent> results = store.search("my-service", 10);
+        assertFalse(results.isEmpty(), "Expected to find event with hyphenated term");
+    }
+
+    @Test
+    void searchWithMultipleHyphenatedTokens() throws SQLException {
+        store.insert(makeEvent("kubectl apply -f kcp-memory-daemon.yaml"));
+        List<ToolEvent> results = store.search("kcp-memory-daemon", 10);
+        assertFalse(results.isEmpty());
+    }
+
+    @Test
+    void searchReturnsEmptyForNoMatch() throws SQLException {
+        store.insert(makeEvent("git status"));
+        List<ToolEvent> results = store.search("nonexistent-term", 10);
+        assertTrue(results.isEmpty());
+    }
+
+    private ToolEvent makeEvent(String command) {
+        return new ToolEvent(
+                0,
+                "2026-05-19T10:00:00Z",
+                "session-abc123",
+                "/src/test-project",
+                "Bash",
+                command,
+                null,
+                null,
+                null,
+                "2026-05-19T10:00:00Z"
+        );
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/store/SessionStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/SessionStoreTest.java
@@ -104,6 +104,34 @@ class SessionStoreTest {
     }
 
     @Test
+    void getByIdOrPrefixReturnsExactMatch() throws SQLException {
+        store.upsert(makeSession("abcdef01-1234-5678-9abc-def012345678", "/src/p", "Exact match"));
+        Session s = store.getByIdOrPrefix("abcdef01-1234-5678-9abc-def012345678");
+        assertNotNull(s);
+        assertEquals("abcdef01-1234-5678-9abc-def012345678", s.getSessionId());
+    }
+
+    @Test
+    void getByIdOrPrefixResolvesEightCharPrefix() throws SQLException {
+        store.upsert(makeSession("abcdef01-1234-5678-9abc-def012345678", "/src/p", "Prefix match"));
+        Session s = store.getByIdOrPrefix("abcdef01");
+        assertNotNull(s);
+        assertEquals("abcdef01-1234-5678-9abc-def012345678", s.getSessionId());
+    }
+
+    @Test
+    void getByIdOrPrefixReturnsNullForAmbiguousPrefix() throws SQLException {
+        store.upsert(makeSession("abcdef01-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "/src/a", "First"));
+        store.upsert(makeSession("abcdef01-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "/src/b", "Second"));
+        assertNull(store.getByIdOrPrefix("abcdef01"));
+    }
+
+    @Test
+    void getByIdOrPrefixReturnsNullForUnknownId() throws SQLException {
+        assertNull(store.getByIdOrPrefix("nonexistent"));
+    }
+
+    @Test
     void statsAggregatesCorrectly() throws SQLException {
         Session s1 = makeSession("sess-008", "/src/x", "Task one");
         s1.setTurnCount(5);


### PR DESCRIPTION
## Summary

- **#33** — `kcp_memory_session_detail` and `kcp_memory_session_tree` now accept the 8-char short IDs that `list`/`search` display. Added `SessionStore.getByIdOrPrefix()`: tries exact match first, falls back to `LIKE prefix%`. Returns null if the prefix is ambiguous (multiple matches).
- **#34** — `kcp_memory_events_search` no longer crashes on queries with `-` (e.g. `my-service`, `kcp-memory`). `EventStore.search()` now routes through `toFtsQuery()`, which wraps each token in FTS5 double-quotes — the same fix already applied in `SessionStore` and `AgentSessionStore`.

## Root causes

| Issue | Root cause |
|-------|-----------|
| #33 | `formatSession()` emits 8-char prefix; `getById()` did exact match only |
| #34 | `EventStore.search()` passed raw user input to `MATCH ?`; FTS5 parses `-` as a column-name negation operator |

## Files changed

- `EventStore.java` — `toFtsQuery()` + wire into `search()`
- `SessionStore.java` — `getByIdOrPrefix()` with exact-then-prefix fallback
- `McpServer.java` — `toolSessionDetail` + `toolSessionTree` use `getByIdOrPrefix`; `toolSessionTree` uses resolved full ID for `listByParent`
- `EventStoreTest.java` — new test class (5 tests inc. hyphen regression)
- `SessionStoreTest.java` — 4 new prefix-lookup tests

## Test plan

- [ ] All 119 tests pass (`mvn test`)
- [ ] `kcp_memory_events_search query="my-service"` no longer throws `[SQLITE_ERROR] no such column: service`
- [ ] `kcp_memory_session_detail session_id=<8-char-prefix>` returns the session
- [ ] `kcp_memory_session_tree session_id=<8-char-prefix>` returns parent + subagents

Closes #33, closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)