### PR TITLE
feat: memory governance — retention, provenance, right-to-forget (#36)

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
+++ b/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
@@ -72,6 +72,7 @@ public class KcpMemoryDaemon {
         server.createContext("/stats",         new StatsHandler(db));
         server.createContext("/scan",          new ScanHandler(db));
         server.createContext("/events/search", new EventsHandler(db));
+        server.createContext("/governance",    new GovernanceHandler(db));
         server.createContext("/ingest",        ingestHandler);
         server.createContext("/nodes",         new NodesHandler(nodeRegistry));
 

--- a/java/src/main/java/com/cantara/kcp/memory/handler/GovernanceHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/GovernanceHandler.java
@@ -1,0 +1,129 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.cantara.kcp.memory.store.SessionStore;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Memory governance endpoints.
+ *
+ * <ul>
+ *   <li>GET  /governance?session=&lt;id&gt;            — governance metadata for a memory
+ *       (provenance, retention, forget tombstone)</li>
+ *   <li>GET  /governance/audit?q=&lt;query&gt;[&limit] — audit the recall gate: which
+ *       matches are surfaced vs. skipped, and why</li>
+ *   <li>POST /governance/retention {session, valid_until} — declare/clear a retention window</li>
+ *   <li>POST /governance/forget    {session, reason}      — exercise the right-to-forget (tombstone)</li>
+ * </ul>
+ */
+public class GovernanceHandler extends BaseHandler {
+
+    private final SessionStore store;
+
+    public GovernanceHandler(MemoryDatabase db) {
+        this.store = new SessionStore(db);
+    }
+
+    @Override
+    public void handle(TcpExchange ex) throws IOException {
+        String path   = ex.getRequestURI().getPath();
+        String method = ex.getRequestMethod();
+        try {
+            if ("GET".equalsIgnoreCase(method) && path.endsWith("/audit")) {
+                handleAudit(ex);
+            } else if ("GET".equalsIgnoreCase(method)) {
+                handleGet(ex);
+            } else if ("POST".equalsIgnoreCase(method) && path.endsWith("/retention")) {
+                handleRetention(ex);
+            } else if ("POST".equalsIgnoreCase(method) && path.endsWith("/forget")) {
+                handleForget(ex);
+            } else {
+                sendError(ex, 405, "Method not allowed");
+            }
+        } catch (Exception e) {
+            sendError(ex, 500, "Governance operation failed: " + e.getMessage());
+        }
+    }
+
+    private void handleGet(TcpExchange ex) throws Exception {
+        String session = queryParams(ex).get("session");
+        if (session == null || session.isBlank()) {
+            sendError(ex, 400, "Missing required parameter: session");
+            return;
+        }
+        SessionStore.Governance g = store.getGovernance(session);
+        if (g == null) {
+            sendError(ex, 404, "No memory for session: " + session);
+            return;
+        }
+        sendJson(ex, 200, g);
+    }
+
+    private void handleAudit(TcpExchange ex) throws Exception {
+        Map<String, String> params = queryParams(ex);
+        String query = params.get("q");
+        if (query == null || query.isBlank()) {
+            sendError(ex, 400, "Missing required parameter: q");
+            return;
+        }
+        int limit = parseLimit(params.getOrDefault("limit", "20"));
+        List<SessionStore.RecallAudit> audit = store.auditSearch(query, limit);
+        long skipped = audit.stream().filter(a -> !a.allowed()).count();
+        sendJson(ex, 200, Map.of(
+                "query", query,
+                "candidates", audit.size(),
+                "skipped", skipped,
+                "results", audit));
+    }
+
+    private void handleRetention(TcpExchange ex) throws Exception {
+        JsonNode body = MAPPER.readTree(readBody(ex));
+        String session = body.path("session").asText("");
+        if (session.isBlank()) {
+            sendError(ex, 400, "Missing required field: session");
+            return;
+        }
+        // null / absent valid_until clears the retention window
+        String validUntil = body.has("valid_until") && !body.get("valid_until").isNull()
+                ? body.get("valid_until").asText() : null;
+        boolean updated = store.setRetention(session, validUntil);
+        if (!updated) {
+            sendError(ex, 404, "No memory for session: " + session);
+            return;
+        }
+        sendJson(ex, 200, mapNullable("session", session, "valid_until", validUntil));
+    }
+
+    private void handleForget(TcpExchange ex) throws Exception {
+        JsonNode body = MAPPER.readTree(readBody(ex));
+        String session = body.path("session").asText("");
+        if (session.isBlank()) {
+            sendError(ex, 400, "Missing required field: session");
+            return;
+        }
+        String reason = body.has("reason") && !body.get("reason").isNull()
+                ? body.get("reason").asText() : null;
+        boolean forgotten = store.forget(session, reason);
+        if (!forgotten) {
+            sendError(ex, 404, "No memory for session: " + session);
+            return;
+        }
+        sendJson(ex, 200, mapNullable("session", session, "forgotten", "true", "reason", reason));
+    }
+
+    private int parseLimit(String raw) {
+        try { return Integer.parseInt(raw); } catch (NumberFormatException e) { return 20; }
+    }
+
+    /** Build a small map tolerating null values (Map.of rejects nulls). */
+    private static Map<String, Object> mapNullable(Object... kv) {
+        java.util.LinkedHashMap<String, Object> m = new java.util.LinkedHashMap<>();
+        for (int i = 0; i + 1 < kv.length; i += 2) m.put((String) kv[i], kv[i + 1]);
+        return m;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -55,6 +55,8 @@ import java.util.logging.Logger;
  *   <li>kcp_memory_subagent_search — FTS5 search within subagent transcripts (v0.5.0)</li>
  *   <li>kcp_memory_session_tree    — parent session + all child agents as a tree (v0.5.0)</li>
  *   <li>kcp_memory_analyze        — manifest quality metrics: retry/help/error rates per manifest key (v0.16.0)</li>
+ *   <li>kcp_memory_forget         — right-to-forget: tombstone a memory so recall never surfaces it (v0.33.0)</li>
+ *   <li>kcp_memory_retention      — declare/clear a retention window (valid_until) on a memory (v0.33.0)</li>
  * </ul>
  */
 public class McpServer {
@@ -233,6 +235,27 @@ public class McpServer {
                         .optional("by_version",  "boolean", "Group by manifest content hash to compare before/after improvements")
         ));
 
+        tools.add(tool(
+                "kcp_memory_forget",
+                "Right-to-forget: permanently tombstone a memory (session) so it is never surfaced " +
+                "by search or list again. The row is retained for audit but excluded from all recall. " +
+                "Use when a session must be governed out of memory — e.g. it contains a secret, was " +
+                "mistaken, or the user asked to forget it. Added in v0.33.0.",
+                schema()
+                        .required("session_id", "string", "Session ID from a kcp_memory_search or kcp_memory_list result")
+                        .optional("reason",     "string", "Audit reason recorded with the forget")
+        ));
+
+        tools.add(tool(
+                "kcp_memory_retention",
+                "Declare (or clear) a retention window on a memory (session). After valid_until passes, " +
+                "the memory is expired and recall skips it. Pass an empty valid_until to clear any expiry. " +
+                "Added in v0.33.0.",
+                schema()
+                        .required("session_id",  "string", "Session ID to govern")
+                        .optional("valid_until", "string", "ISO-8601 UTC expiry (e.g. 2026-12-31T00:00:00Z); empty clears it")
+        ));
+
         return result;
     }
 
@@ -265,6 +288,8 @@ public class McpServer {
                 case "kcp_memory_subagent_search" -> toolSubagentSearch(args);
                 case "kcp_memory_session_tree"    -> toolSessionTree(args);
                 case "kcp_memory_analyze"         -> toolAnalyze(args);
+                case "kcp_memory_forget"          -> toolForget(args);
+                case "kcp_memory_retention"       -> toolRetention(args);
                 default                            -> "Unknown tool: " + name;
             };
         } catch (Exception e) {
@@ -358,6 +383,38 @@ public class McpServer {
             topTools.forEach(t -> sb.append(String.format("  %-25s %,d%n", t.toolName(), t.count())));
         }
         return sb.toString();
+    }
+
+    private String toolForget(JsonNode args) throws Exception {
+        String sessionId = args.path("session_id").asText("").strip();
+        if (sessionId.isEmpty()) return "Error: session_id is required";
+        String reason = args.path("reason").asText("").strip();
+
+        SessionStore store = new SessionStore(db);
+        Session s = store.getByIdOrPrefix(sessionId);
+        if (s == null) return "Session not found: " + sessionId;
+
+        boolean ok = store.forget(s.getSessionId(), reason.isEmpty() ? null : reason);
+        if (!ok) return "Session not found: " + sessionId;
+        return "Forgotten: " + s.getSessionId()
+                + " — will no longer be surfaced by recall."
+                + (reason.isEmpty() ? "" : " Reason: " + reason);
+    }
+
+    private String toolRetention(JsonNode args) throws Exception {
+        String sessionId = args.path("session_id").asText("").strip();
+        if (sessionId.isEmpty()) return "Error: session_id is required";
+        String validUntil = args.path("valid_until").asText("").strip();
+
+        SessionStore store = new SessionStore(db);
+        Session s = store.getByIdOrPrefix(sessionId);
+        if (s == null) return "Session not found: " + sessionId;
+
+        boolean ok = store.setRetention(s.getSessionId(), validUntil.isEmpty() ? null : validUntil);
+        if (!ok) return "Session not found: " + sessionId;
+        return validUntil.isEmpty()
+                ? "Retention cleared for " + s.getSessionId() + " — memory no longer expires."
+                : "Retention set for " + s.getSessionId() + " — expires " + validUntil + ".";
     }
 
     private String toolSessionDetail(JsonNode args) throws Exception {
@@ -608,6 +665,9 @@ public class McpServer {
             if (msg.length() > 120) msg = msg.substring(0, 120) + "…";
             sb.append("\"").append(msg).append("\"\n");
         }
+        if (r.getProvenance() != null) sb.append("provenance: ").append(r.getProvenance());
+        if (r.getValidUntil() != null) sb.append("  (valid until ").append(r.getValidUntil()).append(")");
+        if (r.getProvenance() != null || r.getValidUntil() != null) sb.append("\n");
         sb.append("\n");
         return sb.toString();
     }

--- a/java/src/main/java/com/cantara/kcp/memory/model/SearchResult.java
+++ b/java/src/main/java/com/cantara/kcp/memory/model/SearchResult.java
@@ -16,6 +16,8 @@ public class SearchResult {
     private int toolCallCount;
     private String firstMessage;
     private double rank;        // FTS rank (lower = more relevant), 0 if non-FTS
+    private String provenance;  // governance: origin descriptor of this memory
+    private String validUntil;  // governance: retention expiry (ISO-8601 UTC), null = no expiry
 
     public SearchResult() {}
 
@@ -51,4 +53,10 @@ public class SearchResult {
 
     public double getRank()               { return rank; }
     public void setRank(double v)         { this.rank = v; }
+
+    public String getProvenance()         { return provenance; }
+    public void setProvenance(String v)   { this.provenance = v; }
+
+    public String getValidUntil()         { return validUntil; }
+    public void setValidUntil(String v)   { this.validUntil = v; }
 }

--- a/java/src/main/java/com/cantara/kcp/memory/model/Session.java
+++ b/java/src/main/java/com/cantara/kcp/memory/model/Session.java
@@ -21,6 +21,7 @@ public class Session {
     private String firstMessage;
     private String allUserText;
     private String scannedAt;
+    private String provenance;   // governance: origin descriptor; auto-derived if null
 
     public Session() {}
 
@@ -65,4 +66,7 @@ public class Session {
 
     public String getScannedAt()             { return scannedAt; }
     public void setScannedAt(String v)       { this.scannedAt = v; }
+
+    public String getProvenance()            { return provenance; }
+    public void setProvenance(String v)      { this.provenance = v; }
 }

--- a/java/src/main/java/com/cantara/kcp/memory/store/GovernanceGate.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/GovernanceGate.java
@@ -1,0 +1,68 @@
+package com.cantara.kcp.memory.store;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Temporal governance gate for recalled memory entries.
+ *
+ * <p>Mirrors the KCP planner's temporal gate: a memory that has been
+ * <em>forgotten</em> (right-to-forget tombstone) or whose <em>retention
+ * window</em> has expired is skipped from recall, and a written reason is
+ * produced so the decision is auditable.
+ *
+ * <p>All timestamps are ISO-8601 UTC (e.g. {@code 2026-07-22T10:00:00Z}).
+ * The gate is pure and side-effect free so it can be unit-tested in isolation
+ * and reused by both the fast SQL recall path and the audit path.
+ */
+public final class GovernanceGate {
+
+    private GovernanceGate() {}
+
+    /**
+     * A gate decision for one memory entry.
+     *
+     * @param allowed true if the memory may be surfaced by recall
+     * @param reason  human-readable audit reason (null when allowed with no note)
+     */
+    public record Decision(boolean allowed, String reason) {
+        public static Decision allow()              { return new Decision(true, null); }
+        public static Decision skip(String reason)  { return new Decision(false, reason); }
+    }
+
+    /**
+     * Evaluate the governance state of a single memory entry.
+     *
+     * @param validUntil  retention expiry (ISO-8601 UTC), or null for no expiry
+     * @param forgottenAt tombstone timestamp (ISO-8601 UTC), or null if live
+     * @param forgetReason optional reason recorded with the forget
+     * @param now         the instant to evaluate against
+     */
+    public static Decision evaluate(String validUntil, String forgottenAt,
+                                    String forgetReason, Instant now) {
+        // Right-to-forget takes precedence — a forgotten memory is never surfaced.
+        if (forgottenAt != null && !forgottenAt.isBlank()) {
+            String why = (forgetReason != null && !forgetReason.isBlank())
+                    ? forgetReason : "no reason given";
+            return Decision.skip("forgotten at " + forgottenAt + " (" + why + ")");
+        }
+
+        // Retention window — skip once the entry is past its valid_until.
+        if (validUntil != null && !validUntil.isBlank()) {
+            Instant expiry;
+            try {
+                expiry = Instant.parse(validUntil.trim());
+            } catch (DateTimeParseException e) {
+                // A malformed retention window is treated as expired: fail closed
+                // rather than surface a memory whose governance we cannot verify.
+                return Decision.skip("unparseable retention window: " + validUntil);
+            }
+            if (!now.isBefore(expiry)) {
+                return Decision.skip("retention window expired at " + validUntil
+                        + " (now " + now + ")");
+            }
+        }
+
+        return Decision.allow();
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
@@ -75,7 +75,8 @@ public class MemoryDatabase implements AutoCloseable {
                 "/db/V4__output_preview.sql",
                 "/db/V5__manifest_version.sql",
                 "/db/V6__peer_sync.sql",
-                "/db/V7__pending_tasks.sql"}) {
+                "/db/V7__pending_tasks.sql",
+                "/db/V8__memory_governance.sql"}) {
 
             String version = resource.substring(resource.lastIndexOf('/') + 1, resource.lastIndexOf('.'));
 
@@ -127,7 +128,9 @@ public class MemoryDatabase implements AutoCloseable {
                 new MigrationCheck("V6__peer_sync",
                         "SELECT 1 FROM pragma_table_info('sessions') WHERE name='source_instance'"),
                 new MigrationCheck("V7__pending_tasks",
-                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_tasks'")
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_tasks'"),
+                new MigrationCheck("V8__memory_governance",
+                        "SELECT 1 FROM pragma_table_info('sessions') WHERE name='valid_until'")
         );
         for (MigrationCheck check : checks) {
             boolean present;

--- a/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
@@ -24,12 +24,18 @@ public class SessionStore {
 
     /** Insert or update a session (upsert by session_id). */
     public void upsert(Session s) throws SQLException {
+        // Every memory carries provenance. Derive one from the session's own
+        // origin when the caller supplies none; on conflict we keep any
+        // provenance already recorded so re-scans never clobber it.
+        String provenance = s.getProvenance() != null && !s.getProvenance().isBlank()
+                ? s.getProvenance() : deriveProvenance(s);
         String sql = """
                 INSERT INTO sessions
                   (session_id, project_dir, git_branch, slug, model,
                    started_at, ended_at, turn_count, tool_call_count,
-                   tool_names, files_json, first_message, all_user_text, scanned_at)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                   tool_names, files_json, first_message, all_user_text, scanned_at,
+                   provenance)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 ON CONFLICT(session_id) DO UPDATE SET
                   project_dir     = excluded.project_dir,
                   git_branch      = excluded.git_branch,
@@ -43,7 +49,8 @@ public class SessionStore {
                   files_json      = excluded.files_json,
                   first_message   = excluded.first_message,
                   all_user_text   = excluded.all_user_text,
-                  scanned_at      = excluded.scanned_at
+                  scanned_at      = excluded.scanned_at,
+                  provenance      = COALESCE(sessions.provenance, excluded.provenance)
                 """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1,  s.getSessionId());
@@ -60,8 +67,17 @@ public class SessionStore {
             ps.setString(12, s.getFirstMessage());
             ps.setString(13, s.getAllUserText());
             ps.setString(14, s.getScannedAt());
+            ps.setString(15, provenance);
             ps.executeUpdate();
         }
+    }
+
+    /** Derive a provenance descriptor from a session's own origin. */
+    private static String deriveProvenance(Session s) {
+        String origin = s.getSlug() != null && !s.getSlug().isBlank()
+                ? s.getSlug()
+                : (s.getProjectDir() != null ? s.getProjectDir() : "");
+        return "claude-code:" + origin + "#" + s.getSessionId();
     }
 
     /** Return full session detail by session_id, or null if not found. */
@@ -157,40 +173,65 @@ public class SessionStore {
         }
     }
 
-    /** Full-text search using FTS5. Returns up to limit results. */
+    // ------------------------------------------------------------------
+    // Governance recall gate
+    // ------------------------------------------------------------------
+    // SQL predicate that skips memories which have been forgotten (tombstoned)
+    // or whose retention window has expired. ISO-8601 UTC strings compare
+    // lexicographically, so valid_until > now is a correct temporal test.
+    // The ?-parameter is bound to the current instant. Mirrors GovernanceGate.
+    private static final String RECALL_GATE =
+            " s.forgotten_at IS NULL AND (s.valid_until IS NULL OR s.valid_until > ?) ";
+
+    /**
+     * Full-text search using FTS5, gated by memory governance. Expired or
+     * forgotten memories are skipped and never surfaced. Returns up to limit
+     * live results, each carrying its provenance.
+     */
     public List<SearchResult> search(String query, int limit) throws SQLException {
         String sql = """
                 SELECT s.session_id, s.project_dir, s.git_branch, s.slug, s.model,
                        s.started_at, s.ended_at, s.turn_count, s.tool_call_count,
-                       s.first_message, rank
+                       s.first_message, s.provenance, s.valid_until, rank
                 FROM sessions_fts
                 JOIN sessions s ON sessions_fts.session_id = s.session_id
-                WHERE sessions_fts MATCH ?
+                WHERE sessions_fts MATCH ? AND
+                """ + RECALL_GATE + """
                 ORDER BY rank
                 LIMIT ?
                 """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, toFtsQuery(query));
-            ps.setInt(2, limit);
+            ps.setString(2, nowIso());
+            ps.setInt(3, limit);
             return mapResults(ps.executeQuery());
         }
     }
 
-    /** List sessions, optionally filtered by project dir. Most recent first. */
+    /**
+     * List sessions, optionally filtered by project dir. Most recent first.
+     * Gated by memory governance — expired or forgotten memories are skipped.
+     */
     public List<SearchResult> list(String projectDir, int limit) throws SQLException {
         boolean filtered = projectDir != null && !projectDir.isBlank();
+        String cols = "session_id, project_dir, git_branch, slug, model, started_at, ended_at, "
+                + "turn_count, tool_call_count, first_message, provenance, valid_until";
         String sql = filtered
-                ? "SELECT session_id, project_dir, git_branch, slug, model, started_at, ended_at, turn_count, tool_call_count, first_message FROM sessions WHERE project_dir = ? ORDER BY started_at DESC LIMIT ?"
-                : "SELECT session_id, project_dir, git_branch, slug, model, started_at, ended_at, turn_count, tool_call_count, first_message FROM sessions ORDER BY started_at DESC LIMIT ?";
+                ? "SELECT " + cols + " FROM sessions s WHERE project_dir = ? AND" + RECALL_GATE
+                  + "ORDER BY started_at DESC LIMIT ?"
+                : "SELECT " + cols + " FROM sessions s WHERE" + RECALL_GATE
+                  + "ORDER BY started_at DESC LIMIT ?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
-            if (filtered) {
-                ps.setString(1, projectDir);
-                ps.setInt(2, limit);
-            } else {
-                ps.setInt(1, limit);
-            }
+            int i = 1;
+            if (filtered) ps.setString(i++, projectDir);
+            ps.setString(i++, nowIso());
+            ps.setInt(i, limit);
             return mapResults(ps.executeQuery());
         }
+    }
+
+    private static String nowIso() {
+        return java.time.Instant.now().toString();
     }
 
     /** Aggregate stats. */
@@ -244,6 +285,8 @@ public class SessionStore {
             r.setTurnCount(rs.getInt("turn_count"));
             r.setToolCallCount(rs.getInt("tool_call_count"));
             r.setFirstMessage(rs.getString("first_message"));
+            r.setProvenance(rs.getString("provenance"));
+            r.setValidUntil(rs.getString("valid_until"));
             try { r.setRank(rs.getDouble("rank")); } catch (SQLException ignored) {}
             out.add(r);
         }
@@ -275,6 +318,116 @@ public class SessionStore {
         }
         return out.isEmpty() ? "\"\"" : out.toString();
     }
+
+    // ------------------------------------------------------------------
+    // Governance write API: retention & right-to-forget
+    // ------------------------------------------------------------------
+
+    /**
+     * Declare (or clear) the retention window for a memory. Pass null to remove
+     * any expiry. Returns true if the session exists and was updated.
+     */
+    public boolean setRetention(String sessionId, String validUntil) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "UPDATE sessions SET valid_until = ? WHERE session_id = ?")) {
+            ps.setString(1, validUntil);
+            ps.setString(2, sessionId);
+            return ps.executeUpdate() > 0;
+        }
+    }
+
+    /**
+     * Exercise the right-to-forget: tombstone a memory so recall can never
+     * surface it again. The row is retained (not deleted) so the forget itself
+     * is auditable via {@link #getGovernance(String)}. Returns true if updated.
+     */
+    public boolean forget(String sessionId, String reason) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "UPDATE sessions SET forgotten_at = ?, forget_reason = ? WHERE session_id = ?")) {
+            ps.setString(1, nowIso());
+            ps.setString(2, reason);
+            ps.setString(3, sessionId);
+            return ps.executeUpdate() > 0;
+        }
+    }
+
+    /** Governance metadata for a single memory, or null if the session is unknown. */
+    public Governance getGovernance(String sessionId) throws SQLException {
+        String sql = """
+                SELECT session_id, provenance, valid_until, forgotten_at, forget_reason
+                FROM sessions WHERE session_id = ?
+                """;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, sessionId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) return null;
+                return new Governance(
+                        rs.getString("session_id"),
+                        rs.getString("provenance"),
+                        rs.getString("valid_until"),
+                        rs.getString("forgotten_at"),
+                        rs.getString("forget_reason"));
+            }
+        }
+    }
+
+    /**
+     * Audit the recall gate for a query: run FTS <em>without</em> the gate and
+     * attach a {@link GovernanceGate.Decision} to every candidate, so an
+     * operator can see which memories were surfaced and which were skipped and
+     * why. This is the audit counterpart to {@link #search(String, int)}.
+     */
+    public List<RecallAudit> auditSearch(String query, int limit) throws SQLException {
+        String sql = """
+                SELECT s.session_id, s.first_message, s.provenance,
+                       s.valid_until, s.forgotten_at, s.forget_reason, rank
+                FROM sessions_fts
+                JOIN sessions s ON sessions_fts.session_id = s.session_id
+                WHERE sessions_fts MATCH ?
+                ORDER BY rank
+                LIMIT ?
+                """;
+        java.time.Instant now = java.time.Instant.now();
+        List<RecallAudit> out = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, toFtsQuery(query));
+            ps.setInt(2, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    GovernanceGate.Decision d = GovernanceGate.evaluate(
+                            rs.getString("valid_until"),
+                            rs.getString("forgotten_at"),
+                            rs.getString("forget_reason"),
+                            now);
+                    out.add(new RecallAudit(
+                            rs.getString("session_id"),
+                            rs.getString("first_message"),
+                            rs.getString("provenance"),
+                            d.allowed(),
+                            d.reason()));
+                }
+            }
+        }
+        return out;
+    }
+
+    /** Governance metadata for a memory entry. */
+    public record Governance(
+            String sessionId,
+            String provenance,
+            String validUntil,
+            String forgottenAt,
+            String forgetReason
+    ) {}
+
+    /** One audited recall candidate: whether the gate allowed it, and why not. */
+    public record RecallAudit(
+            String sessionId,
+            String firstMessage,
+            String provenance,
+            boolean allowed,
+            String reason
+    ) {}
 
     /** Aggregate statistics across all sessions. */
     public record Stats(

--- a/java/src/main/resources/db/V8__memory_governance.sql
+++ b/java/src/main/resources/db/V8__memory_governance.sql
@@ -1,0 +1,24 @@
+-- kcp-memory v0.33.0 — memory governance
+-- Turns indexed sessions into *governed* memory entries. Three pillars:
+--   (a) retention  — an optional expiry (valid_until); NULL = never expires.
+--   (b) provenance — which source produced the memory (session/tool descriptor).
+--   (c) right-to-forget — an explicit tombstone (forgotten_at + forget_reason).
+-- Recall (search/list) is gated on these: expired or forgotten memories are skipped.
+
+-- (a) retention: ISO-8601 UTC expiry; NULL means the memory never expires.
+ALTER TABLE sessions ADD COLUMN valid_until TEXT;
+-- (b) provenance: origin descriptor of this memory (which source produced it).
+ALTER TABLE sessions ADD COLUMN provenance TEXT;
+-- (c) right-to-forget: ISO-8601 UTC tombstone; NULL means the memory is live.
+ALTER TABLE sessions ADD COLUMN forgotten_at TEXT;
+-- (c) right-to-forget: audit reason recorded with the forget.
+ALTER TABLE sessions ADD COLUMN forget_reason TEXT;
+
+-- Backfill provenance for pre-governance rows so every memory has a traceable origin.
+UPDATE sessions
+   SET provenance = 'claude-code:' || COALESCE(NULLIF(slug, ''), project_dir, '') || '#' || session_id
+ WHERE provenance IS NULL OR provenance = '';
+
+-- Indexes for the recall gate (skip forgotten / expired) and audit queries.
+CREATE INDEX IF NOT EXISTS idx_sessions_forgotten ON sessions(forgotten_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_valid_until ON sessions(valid_until);

--- a/java/src/test/java/com/cantara/kcp/memory/store/GovernanceGateTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/GovernanceGateTest.java
@@ -1,0 +1,75 @@
+package com.cantara.kcp.memory.store;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GovernanceGateTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-22T12:00:00Z");
+
+    @Test
+    void allowsWhenNoConstraints() {
+        GovernanceGate.Decision d = GovernanceGate.evaluate(null, null, null, NOW);
+        assertTrue(d.allowed());
+        assertNull(d.reason());
+    }
+
+    @Test
+    void skipsForgottenMemoryWithReason() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate(null, "2026-07-20T00:00:00Z", "contained a secret", NOW);
+        assertFalse(d.allowed());
+        assertTrue(d.reason().contains("forgotten"));
+        assertTrue(d.reason().contains("contained a secret"));
+    }
+
+    @Test
+    void forgottenWithoutReasonStillHasAuditText() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate(null, "2026-07-20T00:00:00Z", null, NOW);
+        assertFalse(d.allowed());
+        assertTrue(d.reason().contains("no reason given"));
+    }
+
+    @Test
+    void skipsExpiredRetentionWindow() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate("2026-07-01T00:00:00Z", null, null, NOW);
+        assertFalse(d.allowed());
+        assertTrue(d.reason().contains("expired"));
+    }
+
+    @Test
+    void allowsWhenRetentionInFuture() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate("2026-12-31T00:00:00Z", null, null, NOW);
+        assertTrue(d.allowed());
+    }
+
+    @Test
+    void expiryIsInclusiveAtBoundary() {
+        // now == valid_until means the window has closed → skipped
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate("2026-07-22T12:00:00Z", null, null, NOW);
+        assertFalse(d.allowed());
+    }
+
+    @Test
+    void forgetTakesPrecedenceOverValidRetention() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate("2026-12-31T00:00:00Z", "2026-07-21T00:00:00Z", "asked to forget", NOW);
+        assertFalse(d.allowed());
+        assertTrue(d.reason().contains("forgotten"));
+    }
+
+    @Test
+    void failsClosedOnUnparseableRetention() {
+        GovernanceGate.Decision d =
+                GovernanceGate.evaluate("not-a-date", null, null, NOW);
+        assertFalse(d.allowed());
+        assertTrue(d.reason().contains("unparseable"));
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/store/SessionGovernanceTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/SessionGovernanceTest.java
@@ -1,0 +1,192 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.SearchResult;
+import com.cantara.kcp.memory.model.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Governance behaviour of the memory store: provenance, retention, and the
+ * right-to-forget, plus the recall gate that skips expired/forgotten memories.
+ */
+class SessionGovernanceTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private SessionStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb = Files.createTempFile("kcp-gov-test-", ".db");
+        db = new MemoryDatabase(tempDb);
+        store = new SessionStore(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    // --- provenance -----------------------------------------------------
+
+    @Test
+    void provenanceIsAutoDerivedOnUpsert() throws Exception {
+        store.upsert(makeSession("sess-prov", "/src/proj", "Wire up billing"));
+        SessionStore.Governance g = store.getGovernance("sess-prov");
+        assertNotNull(g);
+        assertNotNull(g.provenance());
+        assertTrue(g.provenance().contains("sess-prov"), "provenance should reference the source session");
+    }
+
+    @Test
+    void recalledItemsCarryProvenance() throws Exception {
+        Session s = makeSession("sess-carry", "/src/proj", "OAuth login flow");
+        s.setAllUserText("Implement OAuth login flow with PKCE");
+        store.upsert(s);
+
+        List<SearchResult> results = store.search("OAuth", 5);
+        assertEquals(1, results.size());
+        assertNotNull(results.get(0).getProvenance());
+    }
+
+    @Test
+    void explicitProvenanceIsPreservedAcrossRescans() throws Exception {
+        Session s = makeSession("sess-explicit", "/src/proj", "seed");
+        s.setProvenance("import:legacy-archive#42");
+        store.upsert(s);
+        // Re-scan with no provenance set must not clobber the recorded one.
+        store.upsert(makeSession("sess-explicit", "/src/proj", "seed"));
+        assertEquals("import:legacy-archive#42", store.getGovernance("sess-explicit").provenance());
+    }
+
+    // --- retention gate -------------------------------------------------
+
+    @Test
+    void searchSkipsExpiredMemory() throws Exception {
+        Session s = makeSession("sess-exp", "/src/proj", "Kubernetes deploy notes");
+        s.setAllUserText("Kubernetes deploy rollout strategy");
+        store.upsert(s);
+
+        assertFalse(store.search("Kubernetes", 5).isEmpty());
+
+        store.setRetention("sess-exp", "2000-01-01T00:00:00Z"); // already past
+        assertTrue(store.search("Kubernetes", 5).isEmpty(), "expired memory must not be recalled");
+    }
+
+    @Test
+    void futureRetentionStillRecalls() throws Exception {
+        Session s = makeSession("sess-future", "/src/proj", "Flyway migration");
+        s.setAllUserText("Flyway migration baseline");
+        store.upsert(s);
+        store.setRetention("sess-future", "2099-01-01T00:00:00Z");
+        assertEquals(1, store.search("Flyway", 5).size());
+    }
+
+    @Test
+    void clearingRetentionReExposesMemory() throws Exception {
+        Session s = makeSession("sess-clear", "/src/proj", "Docker build cache");
+        s.setAllUserText("Docker build cache optimization");
+        store.upsert(s);
+        store.setRetention("sess-clear", "2000-01-01T00:00:00Z");
+        assertTrue(store.search("Docker", 5).isEmpty());
+        store.setRetention("sess-clear", null); // clear expiry
+        assertEquals(1, store.search("Docker", 5).size());
+    }
+
+    // --- right-to-forget ------------------------------------------------
+
+    @Test
+    void forgetTombstonesFromRecallButRetainsRow() throws Exception {
+        Session s = makeSession("sess-forget", "/src/proj", "Postgres tuning");
+        s.setAllUserText("Postgres tuning for write throughput");
+        store.upsert(s);
+
+        assertFalse(store.search("Postgres", 5).isEmpty());
+
+        assertTrue(store.forget("sess-forget", "user asked to forget"));
+        assertTrue(store.search("Postgres", 5).isEmpty(), "forgotten memory must not be recalled");
+        assertTrue(store.list("/src/proj", 10).isEmpty(), "forgotten memory must not appear in list");
+
+        // Row retained for audit
+        assertNotNull(store.getById("sess-forget"));
+        SessionStore.Governance g = store.getGovernance("sess-forget");
+        assertNotNull(g.forgottenAt());
+        assertEquals("user asked to forget", g.forgetReason());
+    }
+
+    @Test
+    void forgetUnknownSessionReturnsFalse() throws Exception {
+        assertFalse(store.forget("does-not-exist", "noop"));
+    }
+
+    @Test
+    void listGateSkipsExpiredAndForgotten() throws Exception {
+        store.upsert(makeSession("live-1", "/src/g", "Live one"));
+        store.upsert(makeSession("exp-1", "/src/g", "Expired one"));
+        store.upsert(makeSession("forgot-1", "/src/g", "Forgotten one"));
+
+        store.setRetention("exp-1", "2000-01-01T00:00:00Z");
+        store.forget("forgot-1", "cleanup");
+
+        List<SearchResult> live = store.list("/src/g", 10);
+        assertEquals(1, live.size());
+        assertEquals("live-1", live.get(0).getSessionId());
+    }
+
+    // --- audit ----------------------------------------------------------
+
+    @Test
+    void auditSearchReportsSkippedWithReasons() throws Exception {
+        Session live = makeSession("audit-live", "/src/a", "audit topic alpha");
+        live.setAllUserText("audit topic alpha content");
+        Session exp = makeSession("audit-exp", "/src/a", "audit topic bravo");
+        exp.setAllUserText("audit topic bravo content");
+        Session forgot = makeSession("audit-forgot", "/src/a", "audit topic charlie");
+        forgot.setAllUserText("audit topic charlie content");
+        store.upsert(live);
+        store.upsert(exp);
+        store.upsert(forgot);
+
+        store.setRetention("audit-exp", "2000-01-01T00:00:00Z");
+        store.forget("audit-forgot", "sensitive");
+
+        List<SessionStore.RecallAudit> audit = store.auditSearch("audit", 10);
+        assertEquals(3, audit.size(), "audit must include gated-out candidates");
+
+        var byId = audit.stream().collect(
+                java.util.stream.Collectors.toMap(SessionStore.RecallAudit::sessionId, a -> a));
+        assertTrue(byId.get("audit-live").allowed());
+        assertNull(byId.get("audit-live").reason());
+
+        assertFalse(byId.get("audit-exp").allowed());
+        assertTrue(byId.get("audit-exp").reason().contains("expired"));
+
+        assertFalse(byId.get("audit-forgot").allowed());
+        assertTrue(byId.get("audit-forgot").reason().contains("forgotten"));
+        assertTrue(byId.get("audit-forgot").reason().contains("sensitive"));
+    }
+
+    private Session makeSession(String id, String projectDir, String firstMessage) {
+        Session s = new Session();
+        s.setSessionId(id);
+        s.setProjectDir(projectDir);
+        s.setFirstMessage(firstMessage);
+        s.setAllUserText(firstMessage);
+        s.setStartedAt(Instant.now().toString());
+        s.setScannedAt(Instant.now().toString());
+        s.setTurnCount(2);
+        s.setToolCallCount(3);
+        s.setToolNames(List.of("Read", "Bash"));
+        s.setFiles(List.of());
+        return s;
+    }
+}


### PR DESCRIPTION
First cut of the **memory-governance plane** (#36) — 'the ungoverned stage'. Memory entries become governed:

- Migration `V8`: `valid_until` (retention), `provenance` (auto-derived origin), `forgotten_at` + `forget_reason` (right-to-forget tombstone).
- `GovernanceGate` (pure): forget > retention, inclusive expiry, fail-closed on unparseable dates.
- **Recall gate**: a shared `RECALL_GATE` predicate applied in `search()` + `list()` — expired/forgotten memories are never surfaced; provenance returned per item.
- Surfaces: HTTP `/governance*` + MCP `kcp_memory_forget`/`kcp_memory_retention`.

Tests: **137 green (+18)**. Scoped as MVP — sessions plane only, soft-delete tombstones, no peer-sync (deferrals documented in the issue). Surfaced via ExoCortex.