### PR TITLE
docs: fix stale MCP tool counts, add v0.33.0 governance to README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,13 @@ Three-layer memory model:
 - **Episodic memory:** Past session history (provided by kcp-memory)
 - **Semantic memory:** Codebase knowledge (provided by Synthesis)
 
-Daemon runs on port 7735, scans `~/.claude/projects/` for session transcripts, indexes them into SQLite with FTS5. Provides 6 MCP tools for inline session querying.
+Daemon runs on port 7735, scans `~/.claude/projects/` for session transcripts, indexes them into SQLite with FTS5. Provides 11 MCP tools for inline session querying.
 
 ## Key Entry Points
 - `bin/install.sh` - Installation script
 - `java/` - Java source code
 - CLI: `kcp-memory search`, `kcp-memory scan`, `kcp-memory stats`
-- MCP tools: `kcp_memory_search`, `kcp_memory_events_search`, `kcp_memory_list`, `kcp_memory_stats`, `kcp_memory_session_detail`, `kcp_memory_project_context`
+- MCP tools: `kcp_memory_search`, `kcp_memory_events_search`, `kcp_memory_list`, `kcp_memory_stats`, `kcp_memory_session_detail`, `kcp_memory_project_context`, `kcp_memory_subagent_search`, `kcp_memory_session_tree`, `kcp_memory_analyze`, `kcp_memory_forget`, `kcp_memory_retention`
 - `knowledge.yaml` - KCP manifest
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-Claude Code can now call all six tools inline during any session — no manual CLI call,
-no context-switching: `kcp_memory_search`, `kcp_memory_events_search`, `kcp_memory_list`,
-`kcp_memory_stats`, `kcp_memory_session_detail`, and `kcp_memory_project_context`.
+Claude Code can now call all eleven tools inline during any session — no manual CLI call,
+no context-switching (search, list, stats, session detail, project context, subagent search,
+session tree, manifest analysis, forget, and retention — see **MCP server** below for the
+full table).
 
 ---
 
@@ -227,7 +228,7 @@ before every `kcp_memory_events_search` call.
 
 ## MCP server
 
-The MCP server exposes ten tools over stdio (JSON-RPC 2.0):
+The MCP server exposes eleven tools over stdio (JSON-RPC 2.0):
 
 | Tool | What it answers |
 |------|----------------|
@@ -240,6 +241,8 @@ The MCP server exposes ten tools over stdio (JSON-RPC 2.0):
 | `kcp_memory_subagent_search` | FTS5 search within subagent transcripts — finds architectural discoveries, rejected approaches, and reasoning buried in delegated tasks *(v0.5.0)* |
 | `kcp_memory_session_tree` | Show a parent session and all its child subagents as a tree — reveals delegated scope and per-agent tool usage *(v0.5.0)* |
 | `kcp_memory_analyze` | Manifest quality metrics — retry rate, help-followup rate, error rate per manifest key. Set `by_version=true` to compare before/after a manifest improvement (requires kcp-commands v0.16.0+). *(v0.17.0)* |
+| `kcp_memory_forget` | Right-to-forget: permanently tombstone a session so it's never surfaced by search or list again — row retained for audit, excluded from recall *(v0.33.0)* |
+| `kcp_memory_retention` | Declare (or clear) a retention window on a session — after `valid_until`, recall skips it *(v0.33.0)* |
 
 Registration (`~/.claude/settings.json`):
 
@@ -364,6 +367,14 @@ The HTTP daemon runs on `http://localhost:7735`:
 | `/stats` | GET | Aggregate statistics |
 | `/scan?force=true` | POST | Trigger an incremental scan (async) |
 | `/events/search?q=<query>&limit=20` | GET | FTS5 search over tool-call events *(v0.2.0)* |
+| `/governance?session=<id>` | GET | Governance metadata (provenance, retention, forgotten status) for a session *(v0.33.0)* |
+| `/governance/audit?session=<id>` | GET | Governance audit trail for a session *(v0.33.0)* |
+| `/governance/retention` | POST | Declare or clear a retention window: `{session, valid_until}` *(v0.33.0)* |
+| `/governance/forget` | POST | Exercise the right-to-forget: `{session, reason}` *(v0.33.0)* |
+
+The four `/governance/*` endpoints are registered on the internal (localhost) server only —
+unlike every other endpoint above, they are deliberately **not** exposed on the daemon's
+optional external-facing server.
 
 ```bash
 # Check health
@@ -452,6 +463,11 @@ java --enable-native-access=ALL-UNNAMED -jar ~/.kcp/kcp-memory-daemon.jar search
 | v0.21.0 | **FTS session fix.** `SessionParser` accepted only `"human"` type for user messages, but Claude Code sends `"user"`. All 3,742 sessions had NULL `first_message` — FTS returned 0 results. Fixed with regression test. **After upgrading, run `kcp-memory scan --force`** to repopulate session data. |
 | v0.22.0 | **Documentation and version alignment.** Updated README: 10 MCP tools (was 9), CLI alias note (`--enable-native-access`), FTS fix upgrade instructions. Coordinated release with kcp-commands v0.22.0 and kcp-dashboard v0.22.0. |
 | v0.26.0 | **Ecosystem alignment.** Removed stale v0.20.0 upgrade note from Quick Start. Coordinated release with kcp-commands v0.26.0 and kcp-dashboard v0.26.0. |
+| v0.26.1 | Fix: replace `HttpServer` with `ServerSocket` — fixes Windows MSIX sandbox startup (#20). |
+| v0.27.0 | **Peer sync + external API.** `--peer` (ExoCortex node-to-node sync) and `--serve` (external-facing API for ExoCortex mobile), WebSocket nodes + event broadcast (control plane Phase 1), `/files` browser + `/process` control endpoints, pending-task queue for peer dispatch. |
+| v0.31.0 | Internal/infra changes — no dedicated release notes; see the [v0.27.0...v0.31.0 diff](https://github.com/Cantara/kcp-memory/compare/v0.27.0...v0.31.0). |
+| v0.32.0 | **KCP v0.14 support** — header blocks, expanded units, structured navigation (#31); cross-site manifest links. Fix: `kcp_memory_events_search` crashed on queries containing `-` (FTS5 read it as a column-negation operator) (#34). |
+| v0.33.0 | **Memory governance.** Retention windows, provenance tagging, right-to-forget (#36/#44) — 4 new `/governance/*` HTTP endpoints (internal server only) and 2 new MCP tools, `kcp_memory_forget` + `kcp_memory_retention` (now 11 total). |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 > transcripts, and tool-call events into SQLite+FTS5. Solves the blank-slate
 > problem: every session starts knowing what you were doing.
 
-Available as CLI, HTTP daemon (port 7735), and MCP server (8 tools).
+Available as CLI, HTTP daemon (port 7735), and MCP server (11 tools).
 `kcp_memory_project_context` at session start auto-loads last 5 sessions + 20
 tool events for the current project — no query needed.
 
@@ -28,6 +28,9 @@ Signing key (delegated to Cantara org): https://wiki.cantara.no/.well-known/kcp-
 - `kcp_memory_session_detail` — full content of a specific session
 - `kcp_memory_subagent_search` — search within subagent transcripts
 - `kcp_memory_session_tree` — parent session + all child agents as a tree
+- `kcp_memory_analyze` — manifest quality metrics (retry/help-followup/error rate)
+- `kcp_memory_forget` — right-to-forget: tombstone a session out of recall
+- `kcp_memory_retention` — declare or clear a session's retention window
 
 ## Install
 


### PR DESCRIPTION
## Summary
The v0.33.0 memory-governance release (retention, provenance, right-to-forget) shipped with zero README/CLAUDE.md/llms.txt coverage, and pre-existing tool-count drift got worse (README already said "ten tools" with 9 rows before this release; CLAUDE.md said "6 tools"; llms.txt said "8 tools" — all now fixed to the real 11).

- README "Daemon API" table: added the 4 `/governance/*` endpoints, noted they're internal-server-only.
- README MCP tools table + "Quick start" mention: corrected to eleven tools.
- README "Releases": backfilled v0.26.1 → v0.33.0 from actual `gh release view` output, not guessed.
- CLAUDE.md + llms.txt: tool counts and lists corrected.

## Not included — needs your signing key
`knowledge.yaml` has the same staleness (`app_version: 0.5.0`, should be `0.33.0`; same tool-count drift) but it's ed25519-signed (`knowledge.yaml.sig`) and I don't have the private key. Unlike kcp-agent, this repo's own CI doesn't verify the signature (no local plan/verify test against it), so this won't break CI here — but I'm not shipping a knowingly-invalid signature for external consumers either. Fix needed:
```diff
-app_version: 0.5.0
-updated: "2026-06-20"
+app_version: 0.33.0
+updated: "2026-07-22"
```
plus the same MCP tool list additions as CLAUDE.md/llms.txt. Apply + re-sign at your convenience.

Part of a ship-safety audit across kcp-memory/kcp-harness/kcp-agent/knowledge-context-protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)