### PR TITLE
fix(kcp): declare manifests[] ids, bump kcp_version to 0.29

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -26,7 +26,7 @@ signing:
   signature: "https://raw.githubusercontent.com/Cantara/kcp-memory/main/knowledge\
     .yaml.sig"
 
-kcp_version: "0.26"
+kcp_version: "0.29"
 project: kcp-memory
 app_version: 0.34.0
 updated: "2026-07-23"
@@ -123,9 +123,13 @@ units:
       value: "30693c9663b54e3ba038a30e9af603b53a86001adc0a9dabc6b5f6613a819fda"
 
 manifests:
-  - url: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml
+  # §3.6: `id` is REQUIRED and is how federation.manifest references resolve.
+  # Without it these entries are unreferenceable and the manifest fails validation.
+  - id: kcp-spec
+    url: https://cantara.github.io/knowledge-context-protocol/knowledge.yaml
     relationship: foundation
-  - url: https://wiki.cantara.no/knowledge/projects/kcp.yaml
+  - id: cantara-org
+    url: https://wiki.cantara.no/knowledge/projects/kcp.yaml
     relationship: org-context
 
 relationships:


### PR DESCRIPTION
`kcp validate` failed with **five errors**. This fixes two and leaves three that need the signing key.

## Fixed

Both `manifests[]` entries omitted `id` (§3.6, REQUIRED). Confirmed against the **v0.26.1** validator too — invalid at the version it declares. `federation.manifest` references resolve by `id`, so an entry without one cannot be referenced.

Also bumps `kcp_version` 0.26 → 0.29.

## Not fixed — needs a key holder

```
✗ Unit 'readme':            content_hash does not match content on disk
✗ Unit 'mcp-tools':         content_hash does not match content on disk
✗ Unit 'three-layer-model': content_hash does not match content on disk
```

All three declare the **same** hash and observe the **same** hash, which looks like a copy-paste bug and isn't — all three units point at `README.md`, describing different aspects of one file. So the digest is simply stale: `README.md` changed after the hashes were written.

`kcp sign --update-hashes` refuses to run without `--key`/`--key-id`, so the recompute can't be separated from the re-sign.

**Deliberately not worked around** by teaching CI to pass `--update-hashes`. A `content_hash` exists so a consumer can detect that content drifted from what was signed; a pipeline that silently re-syncs it on every push can never detect anything. Refreshing these should stay a conscious act by a key holder.

## The signature gets fixed as a side effect

Touching `knowledge.yaml` triggers the org signing workflow, **fixed in [Cantara/.github#3](https://github.com/Cantara/.github/pull/3)**. This repo is one of five whose manifests `kcp render` refuses with `tier=failed (unparseable signature file)`; this push replaces that with the RFC-0018 §4.2 envelope.

## One warning surfaced, not introduced

`manifests['cantara-org']` declares `relationship: org-context`, which has never been in the vocabulary (`child | foundation | governs | peer | archive`). The validator skips entries with no `id`, so declaring the id made it visible. `peer` looks like the intent — reported, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)