### PR TITLE
fix(kcp): refresh the stale content_hash digests, and gate on them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,16 @@ jobs:
       - name: Build and test
         working-directory: java
         run: mvn package -q
+
+      # The manifest is a shipped artifact and nothing here checked it. That is how
+      # three content_hash digests went stale against README.md unnoticed: signing
+      # does not catch it (kcp render verifies the signature, not the declared
+      # hashes), so the drift was undetectable by construction.
+      #
+      # Deliberately `validate`, not `sign --update-hashes`. A content_hash exists so
+      # a consumer can detect that content drifted from what was signed; a pipeline
+      # that silently recomputes it on every push launders the drift into a green
+      # build and can never detect anything. Failing here means someone updates the
+      # digest having looked at what changed.
+      - name: Validate knowledge.yaml
+        run: npx --yes @cantara.no/kcp@0.29 validate knowledge.yaml

--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -71,7 +71,7 @@ units:
       ]
     content_hash:
       algorithm: sha256
-      value: "30693c9663b54e3ba038a30e9af603b53a86001adc0a9dabc6b5f6613a819fda"
+      value: "7e9af5207e7cf487b47a4ff4f19e7483c4c8115c37358737192b2c6a6a8e99b5"
 
   - id: mcp-tools
     path: README.md
@@ -98,7 +98,7 @@ units:
       ]
     content_hash:
       algorithm: sha256
-      value: "30693c9663b54e3ba038a30e9af603b53a86001adc0a9dabc6b5f6613a819fda"
+      value: "7e9af5207e7cf487b47a4ff4f19e7483c4c8115c37358737192b2c6a6a8e99b5"
 
   - id: three-layer-model
     path: README.md
@@ -119,7 +119,7 @@ units:
       ]
     content_hash:
       algorithm: sha256
-      value: "30693c9663b54e3ba038a30e9af603b53a86001adc0a9dabc6b5f6613a819fda"
+      value: "7e9af5207e7cf487b47a4ff4f19e7483c4c8115c37358737192b2c6a6a8e99b5"
 
 manifests:
   # §3.6: `id` is REQUIRED and is how federation.manifest references resolve.


### PR DESCRIPTION
Closes #51.

Three units — `readme`, `mcp-tools`, `three-layer-model` — declared `30693c9663b54e3ba038…` while `README.md` now hashes to `7e9af5207e7cf487b47a…`.

All three point at `README.md`, describing different aspects of one file, so the shared digest is correct by design — the file simply changed after it was written. Recomputed **every** declared hash against its unit's path, not just the three the validator named; these are the only ones, and all three were stale.

## The digest update alone buys about one commit

The second half is the point: **nothing in CI validated this manifest.** `ci.yml` didn't touch it, and `sign-kcp.yml` only signs it — which doesn't help, because `kcp render` verifies the *signature*, not the declared hashes. A manifest with three stale digests renders `tier: known` quite happily.

The drift was undetectable by construction. It surfaced only because a manual `kcp validate` was run while fixing something else.

## Why `validate`, not `sign --update-hashes`

That's the obvious fix and the wrong one. A `content_hash` exists so a consumer can detect that content drifted from what was signed. A pipeline that silently recomputes it on every push launders the drift into a green build and can never detect anything.

Failing loudly means the next person updates the digest **having looked at what changed**.

## Verified, not assumed

| | `kcp validate` |
|---|---|
| append a line to `README.md` | exit **1** |
| restore it | exit **0** |

## Untouched

`manifests['cantara-org']` declares `relationship: org-context`, which has never been in the vocabulary (`child \| foundation \| governs \| peer \| archive`). `peer` looks like the intent, but changing a declared relationship is a semantic call for whoever wrote it. It's a warning, so it doesn't fail the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)