### PR TITLE
chore(kcp): bump knowledge.yaml to kcp_version 0.30

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -25,7 +25,7 @@ signing:
   public_key: "MCowBQYDK2VwAyEAuipgusnqU9vjf3p2yPVLD/DmERT6tBbLOqEETdxAhMU="
   signature: "knowledge.yaml.sig"
 
-kcp_version: "0.29"
+kcp_version: "0.30"
 project: kcp-memory
 app_version: 0.34.0
 updated: "2026-07-23"


### PR DESCRIPTION
Bumps `kcp_version` 0.29 → [0.30](https://github.com/Cantara/knowledge-context-protocol/releases/tag/v0.30.0), which adds `load_eligible` (§4.3c) and the rule that **eligibility does not compose**.

`kcp validate` is clean at 0.30 (remaining warnings, where present, are pre-existing and unrelated).

Touching `knowledge.yaml` also re-runs the org signing workflow, which since [Cantara/.github#3](https://github.com/Cantara/.github/pull/3) signs with `kcp sign` and verifies with `kcp render` before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)