### PR TITLE
chore(deps): consolidated dependency sweep — jackson, junit 6, surefire, checkout v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 21
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Java 21
         uses: actions/setup-java@v5

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,9 +26,9 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sqlite.version>3.53.2.1</sqlite.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <picocli.version>4.7.7</picocli.version>
-        <junit.version>5.14.3</junit.version>
+        <junit.version>6.0.2</junit.version>
     </properties>
 
     <dependencies>
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </plugin>
 
             <!-- Shade plugin: fat JAR -->


### PR DESCRIPTION
Consolidates five open Renovate PRs into one tested change.

| Dependency | From | To | Supersedes |
|---|---|---|---|
| `jackson-databind` | 2.21.2 | 2.22.1 | #30 |
| `junit-jupiter` | 5.14.3 | **6.0.2** | #39 (and #29's 5.14.4) |
| `maven-surefire-plugin` | 3.5.5 | 3.5.6 | #38 |
| `actions/checkout` | v6 | v7 | #40 |

`sqlite-jdbc` 3.53.2.1 (#27) merged separately and is already on main.

## Why consolidated

Each of these edits an adjacent line in `pom.xml`'s `<properties>` block. Merging #27 immediately put #30 into `CONFLICTING/DIRTY` — GitHub could not even update the branch. Merging five sequentially means five rebase cycles, and each intermediate state is a combination that never ships. This tests the combination that does.

## JUnit 6 verification

The major here is JUnit 6. A green build proves less than it appears: if platform discovery breaks, surefire runs **zero** tests and still exits 0. So the check is the count, not the exit code.

```
Tests run: 144, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

144 — the same count as before the bump.

Closes #29, #30, #38, #39, #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)