### PR TITLE
chore(release): v0.35.0 — KCP 0.30, signature repair, dependency currency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cantara.kcp</groupId>
     <artifactId>kcp-memory</artifactId>
-    <version>0.34.0</version>
+    <version>0.35.0</version>
     <packaging>jar</packaging>
 
     <name>kcp-memory</name>

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -64,7 +64,7 @@ public class McpServer {
 
     private static final Logger LOG              = Logger.getLogger(McpServer.class.getName());
     private static final String PROTOCOL_VERSION = "2024-11-05";
-    public  static final String SERVER_VERSION   = "0.34.0";
+    public  static final String SERVER_VERSION   = "0.35.0";
 
     private final ObjectMapper   mapper = new ObjectMapper();
     private final MemoryDatabase db;


### PR DESCRIPTION
12 commits since v0.34.0. **Minor**: the manifest tracks KCP 0.30, and the signature it ships now verifies.

| Area | What |
|---|---|
| KCP 0.30 | manifest bumped as the spec moved; stale `content_hash` digests refreshed and gated in CI |
| Signatures | the reference resolved from `main` rather than beside the manifest, so verification fetched one for a different revision |
| Deps | jackson 2.22.1, junit-jupiter **6.1.2**, surefire 3.5.6, sqlite-jdbc 3.53.2.1, actions/checkout v7 |

JUnit 6 is a major and was checked beyond the exit code — broken platform discovery exits 0 having run *nothing*, so the check is the count: **144 tests run**, the same as before the bump.

`mvn test` passes; `kcp validate` clean apart from a pre-existing `org-context` relationship warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)