### PR TITLE
Declare the four exocortex operational skills as governed procedures

### DIFF
--- a/knowledge.yaml
+++ b/knowledge.yaml
@@ -121,6 +121,71 @@ units:
       algorithm: sha256
       value: "7e9af5207e7cf487b47a4ff4f19e7483c4c8115c37358737192b2c6a6a8e99b5"
 
+  # The procedural plane (§4.3a, RFC-0028): kcp-memory's four operational skills declared
+  # as governed procedures. Tool names are Claude Code's — the runtime that adjudicates
+  # them here.
+
+  - id: exocortex-serve-setup
+    path: .claude/skills/exocortex-serve-setup/SKILL.md
+    kind: skill
+    intent: "How does an operator configure and test the kcp-memory --serve external API for mobile access?"
+    scope: project
+    audience: [agent, operator]
+    triggers: [serve, external API, android access, api key, port 8443]
+    load_eligible: true
+    action_scope:
+      tools: [Bash, Read]
+      capabilities: ["exocortex.serve-setup"]
+    content_hash:
+      algorithm: sha256
+      value: "ef685eba0628b1735b29c7443b684884d34eb78a53402cca3be68157047b2d36"
+
+  - id: exocortex-peer-setup
+    path: .claude/skills/exocortex-peer-setup/SKILL.md
+    kind: skill
+    intent: "How does an operator configure and test --peer connections between ExoCortex instances?"
+    scope: project
+    audience: [agent, operator]
+    triggers: [peer, sync, fleet, connect instances, peer connection]
+    load_eligible: true
+    action_scope:
+      tools: [Bash, Read]
+      capabilities: ["exocortex.peer-setup"]
+    content_hash:
+      algorithm: sha256
+      value: "98aaa01efeef23e44f44181cb97ceee6a66518e887f464d0a4085c4321b57c89"
+
+  - id: exocortex-debug
+    path: .claude/skills/exocortex-debug/SKILL.md
+    kind: skill
+    intent: "How does an operator diagnose sync issues, tunnel failures, and event-flow problems across the ExoCortex fleet?"
+    scope: project
+    audience: [agent, operator]
+    triggers: [debug, sync issue, tunnel, event flow, diagnose]
+    load_eligible: true
+    action_scope:
+      # Diagnosis reads and probes; it does not edit the systems it is diagnosing.
+      tools: [Bash, Read, Grep]
+      capabilities: ["exocortex.debug"]
+    content_hash:
+      algorithm: sha256
+      value: "f7a2e01617d683d94f4e29a1ac947c155c117038361415e4e38b17ff175f8cdf"
+
+  - id: exocortex-android-app
+    path: .claude/skills/exocortex-android-app/SKILL.md
+    kind: skill
+    intent: "How does a developer navigate, build, and avoid the known gotchas of the kcp-sync-android control plane?"
+    scope: project
+    audience: [agent]
+    triggers: [android, kcp-sync-android, control plane, build apk]
+    load_eligible: true
+    action_scope:
+      tools: [Bash, Read, Edit, Write, Grep]
+      capabilities: ["exocortex.android-dev"]
+    content_hash:
+      algorithm: sha256
+      value: "748891026a1df0b0b981e394c9553fcb538d819e88831300e24867ccf9c74aa2"
+
 manifests:
   # §3.6: `id` is REQUIRED and is how federation.manifest references resolve.
   # Without it these entries are unreferenceable and the manifest fails validation.

--- a/knowledge.yaml.sig
+++ b/knowledge.yaml.sig
@@ -2,5 +2,5 @@
   "key_id": "cantara-repos-2026",
   "algorithm": "EdDSA",
   "public_key": "MCowBQYDK2VwAyEAuipgusnqU9vjf3p2yPVLD/DmERT6tBbLOqEETdxAhMU=",
-  "signature": "z1sBBswrB0J14XNyhKrVy1toV2/LHkxxLX2a+0JPVJXzhmq8by1Jqx0G7SXx3S08Pn1k4dTIt9W4/1zEKi3DDg=="
+  "signature": "PDC7+vce2KwdHqx3aLE0SF7mu97kXe0bY+uTd4okGKD6kHVQUXJphqNFjmMtvso9afZBVVi24HLH0RWNuJ0NAg=="
 }


### PR DESCRIPTION
All four existed as SKILL.md files the planner rightly called `not a governed procedure`. Now `kind: skill` with explicit `load_eligible` grants (RFC-0028), `action_scope` drawn from what each skill does (debug reads and probes; it does not edit what it diagnoses), and `content_hash` per source.

Verified against the real planner: **4 of 4** report `kind: skill with explicit eligibility grant`. `kcp-agent validate` → ok, 0 findings. Manifest re-signed via `sign-kcp` workflow_dispatch.

Part of the ecosystem procedural-plane pass — spec repo (4), kcp-triage (9), pi-kcp (3) already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)