### PR TITLE
Decision memory MCP tool (kcp_memory_decisions) — continuation of #36 by @StigLau

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -53,6 +53,13 @@
             <version>${picocli.version}</version>
         </dependency>
 
+        <!-- SnakeYAML for decision memory -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -1,15 +1,18 @@
 package com.cantara.kcp.memory.mcp;
 
 import com.cantara.kcp.memory.model.AgentSession;
+import com.cantara.kcp.memory.model.Decision;
 import com.cantara.kcp.memory.model.ManifestQualityRecord;
 import com.cantara.kcp.memory.model.ManifestVersionRecord;
 import com.cantara.kcp.memory.model.SearchResult;
 import com.cantara.kcp.memory.model.Session;
 import com.cantara.kcp.memory.model.ToolEvent;
 import com.cantara.kcp.memory.scanner.AgentSessionScanner;
+import com.cantara.kcp.memory.scanner.DecisionScanner;
 import com.cantara.kcp.memory.scanner.EventLogScanner;
 import com.cantara.kcp.memory.scanner.SessionScanner;
 import com.cantara.kcp.memory.store.AgentSessionStore;
+import com.cantara.kcp.memory.store.DecisionStore;
 import com.cantara.kcp.memory.store.EventStore;
 import com.cantara.kcp.memory.store.GovernanceGate;
 import com.cantara.kcp.memory.store.ManifestQualityStore;
@@ -79,6 +82,7 @@ public class McpServer {
         new SessionScanner(db).scan(false);
         new EventLogScanner(db).scan();
         new AgentSessionScanner(db).scan(false);
+        new DecisionScanner(db).scan();
 
         // stdout = protocol; auto-flush so responses are sent immediately
         PrintWriter    out = new PrintWriter(System.out, true);
@@ -257,6 +261,21 @@ public class McpServer {
                         .optional("valid_until", "string", "ISO-8601 UTC expiry (e.g. 2026-12-31T00:00:00Z); empty clears it")
         ));
 
+        tools.add(tool(
+                "kcp_memory_decisions",
+                "Query the decision memory index — architectural decisions, constraints, and anti-patterns " +
+                "discovered across Claude Code sessions. Indexed from project .sdd/decisions/*.yaml files. " +
+                "Prevents re-reasoning about past decisions and avoids repeating known failures. " +
+                "Use this to recall 'what did we decide about X?' or 'what are the known constraints for Y?' " +
+                "Example queries: 'Lambda deployment', 'video codec alpha channel', 'testing credentials'. " +
+                "Added in v0.36.0.",
+                schema()
+                        .required("query",  "string",  "Search terms — keywords matched against decision what/why/tags/domain")
+                        .optional("type",   "string",  "Filter by type: decision | anti-pattern | constraint | workaround")
+                        .optional("domain", "string",  "Filter by domain: deployment | testing | video-build | etc.")
+                        .optional("limit",  "integer", "Max results (default 10)")
+        ));
+
         return result;
     }
 
@@ -291,6 +310,7 @@ public class McpServer {
                 case "kcp_memory_analyze"         -> toolAnalyze(args);
                 case "kcp_memory_forget"          -> toolForget(args);
                 case "kcp_memory_retention"       -> toolRetention(args);
+                case "kcp_memory_decisions"       -> toolDecisions(args);
                 default                            -> "Unknown tool: " + name;
             };
         } catch (Exception e) {
@@ -753,6 +773,77 @@ public class McpServer {
         error.put("code",    code);
         error.put("message", message);
         return mapper.writeValueAsString(resp);
+    }
+
+    private String toolDecisions(JsonNode args) throws Exception {
+        String query  = args.path("query").asText("").strip();
+        String type   = args.path("type").asText(null);
+        String domain = args.path("domain").asText(null);
+        int    limit  = args.path("limit").asInt(10);
+
+        if (query.isEmpty() && (type == null || type.isBlank()) && (domain == null || domain.isBlank())) {
+            return "Error: query, type, or domain required";
+        }
+
+        DecisionStore store = new DecisionStore(db);
+        List<Decision> results;
+
+        // If query is provided, use FTS search; otherwise filter by type/domain
+        if (!query.isEmpty()) {
+            results = store.search(query, limit);
+            // Further filter by type/domain if provided
+            if ((type != null && !type.isBlank()) || (domain != null && !domain.isBlank())) {
+                String finalType = type;
+                String finalDomain = domain;
+                results = results.stream()
+                        .filter(d -> (finalType == null || finalType.isBlank() || d.type().equals(finalType)))
+                        .filter(d -> (finalDomain == null || finalDomain.isBlank() || d.domain().equals(finalDomain)))
+                        .limit(limit)
+                        .toList();
+            }
+        } else {
+            // No query, just filter
+            results = store.filter(type, domain, limit);
+        }
+
+        UsageLogger.logDecisionQuery(query, type, domain, results.size());
+
+        if (results.isEmpty()) {
+            return String.format("No decisions found for: query='%s' type='%s' domain='%s'",
+                    query, type != null ? type : "", domain != null ? domain : "");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(results.size()).append(" decision(s) found:\n\n");
+
+        for (Decision d : results) {
+            sb.append("## ").append(d.id()).append("\n");
+            sb.append("**Type**: ").append(d.type()).append("  |  ");
+            sb.append("**Domain**: ").append(d.domain()).append("\n");
+            sb.append("**What**: ").append(d.what()).append("\n");
+            sb.append("**Why**: ").append(d.why()).append("\n");
+
+            if (d.alternatives() != null && !d.alternatives().isEmpty()) {
+                sb.append("**Alternatives**:\n");
+                for (String alt : d.alternatives()) {
+                    sb.append("  - ").append(alt).append("\n");
+                }
+            }
+
+            sb.append("**Learned**: ").append(d.learned()).append("\n");
+            if (d.updated() != null && !d.updated().isBlank()) {
+                sb.append("**Updated**: ").append(d.updated()).append("\n");
+            }
+
+            if (d.tags() != null && !d.tags().isEmpty()) {
+                sb.append("**Tags**: ").append(String.join(", ", d.tags())).append("\n");
+            }
+
+            sb.append("**Project**: ").append(d.projectPath()).append("\n");
+            sb.append("\n");
+        }
+
+        return sb.toString();
     }
 
     // ------------------------------------------------------------------

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/UsageLogger.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/UsageLogger.java
@@ -64,6 +64,24 @@ public final class UsageLogger {
         });
     }
 
+    /** Log a decision query event asynchronously — returns immediately. */
+    public static void logDecisionQuery(String query, String type, String domain, int resultCount) {
+        Thread.ofVirtual().start(() -> {
+            try {
+                ensureSchema();
+                String project = projectFromPwd();
+                // Store type/domain in query field as structured: "query=X type=Y domain=Z"
+                String fullQuery = String.format("query=%s type=%s domain=%s",
+                        query != null ? query : "",
+                        type != null ? type : "",
+                        domain != null ? domain : "");
+                insert("decision_query", project, fullQuery, null, resultCount, null, null, null);
+            } catch (Exception e) {
+                System.err.println("[kcp-memory UsageLogger] decision query failed: " + e);
+            }
+        });
+    }
+
     private static String projectFromPwd() {
         String pwd = System.getenv("PWD");
         if (pwd == null || pwd.isBlank()) return "unknown";

--- a/java/src/main/java/com/cantara/kcp/memory/model/Decision.java
+++ b/java/src/main/java/com/cantara/kcp/memory/model/Decision.java
@@ -1,0 +1,33 @@
+package com.cantara.kcp.memory.model;
+
+import java.util.List;
+
+/**
+ * Decision record from project .sdd/decisions/*.yaml files.
+ * Represents architectural decisions, constraints, anti-patterns, and workarounds
+ * discovered across Claude Code sessions.
+ */
+public record Decision(
+        String id,
+        String type,           // decision | anti-pattern | constraint | workaround
+        String domain,         // deployment | testing | video-build | etc.
+        String what,           // One-sentence summary
+        String why,            // Reasoning/context
+        List<String> alternatives,  // What was rejected (optional)
+        String learned,        // Session ID or skill where discovered
+        String updated,        // Session ID if decision revised (optional)
+        List<String> tags,     // Keywords for search
+        String projectPath     // Which project this came from
+) {
+    public Decision {
+        if (id == null || id.isBlank()) throw new IllegalArgumentException("id required");
+        if (type == null || type.isBlank()) throw new IllegalArgumentException("type required");
+        if (domain == null || domain.isBlank()) throw new IllegalArgumentException("domain required");
+        if (what == null || what.isBlank()) throw new IllegalArgumentException("what required");
+        if (why == null || why.isBlank()) throw new IllegalArgumentException("why required");
+        if (projectPath == null || projectPath.isBlank()) throw new IllegalArgumentException("projectPath required");
+
+        alternatives = alternatives == null ? List.of() : List.copyOf(alternatives);
+        tags = tags == null ? List.of() : List.copyOf(tags);
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/scanner/DecisionScanner.java
+++ b/java/src/main/java/com/cantara/kcp/memory/scanner/DecisionScanner.java
@@ -1,0 +1,190 @@
+package com.cantara.kcp.memory.scanner;
+
+import com.cantara.kcp.memory.model.Decision;
+import com.cantara.kcp.memory.store.DecisionStore;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Scans known project directories for .sdd/decisions/*.yaml files and indexes them.
+ * Discovers decisions across all projects so kcp_memory_decisions can query globally.
+ */
+public class DecisionScanner {
+
+    private static final Logger LOG = Logger.getLogger(DecisionScanner.class.getName());
+
+    private static final Path DEFAULT_CLAUDE_PROJECTS =
+            Path.of(System.getProperty("user.home"), ".claude", "projects");
+
+    private final List<Path> roots;
+    private final DecisionStore store;
+    private final Yaml yaml;
+
+    public DecisionScanner(MemoryDatabase db) {
+        this(List.of(DEFAULT_CLAUDE_PROJECTS), db);
+    }
+
+    public DecisionScanner(List<Path> roots, MemoryDatabase db) {
+        this.roots = List.copyOf(roots);
+        this.store = new DecisionStore(db);
+        this.yaml = new Yaml();
+    }
+
+    /**
+     * Scan all configured roots for decision YAML files.
+     *
+     * @return scan result summary
+     */
+    public ScanResult scan() {
+        List<String> errors = new ArrayList<>();
+        int indexed = 0, skipped = 0;
+
+        try {
+            Set<Path> projectRoots = discoverProjects();
+            for (Path projectRoot : projectRoots) {
+                try {
+                    int count = scanProject(projectRoot);
+                    if (count > 0) indexed += count;
+                    else skipped++;
+                } catch (Exception e) {
+                    errors.add(projectRoot + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            errors.add("Discovery error: " + e.getMessage());
+        }
+
+        LOG.info(String.format("Decision scan complete: %d decisions indexed, %d projects skipped, %d errors",
+                indexed, skipped, errors.size()));
+        return new ScanResult(indexed, skipped, errors.size(), errors);
+    }
+
+    /**
+     * Discover project root directories by walking Claude projects and extracting project_dir.
+     */
+    private Set<Path> discoverProjects() throws IOException {
+        Set<Path> projects = new LinkedHashSet<>();
+
+        for (Path root : roots) {
+            if (!Files.exists(root)) continue;
+
+            Files.walkFileTree(root, Set.of(), 3, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (file.getFileName().toString().equals("project.json")) {
+                        try {
+                            String content = Files.readString(file);
+                            // Extract project_dir from JSON (simple string search, no full JSON parse)
+                            int dirIdx = content.indexOf("\"project_dir\"");
+                            if (dirIdx > 0) {
+                                int start = content.indexOf("\"", dirIdx + 13) + 1;
+                                int end = content.indexOf("\"", start);
+                                String projectDir = content.substring(start, end);
+                                Path projectPath = Path.of(projectDir);
+                                if (Files.exists(projectPath)) {
+                                    projects.add(projectPath);
+                                }
+                            }
+                        } catch (IOException e) {
+                            LOG.warning("Failed to read project.json: " + file + " — " + e.getMessage());
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+
+        return projects;
+    }
+
+    /**
+     * Scan a single project for .sdd/decisions/*.yaml files and index them.
+     *
+     * @return number of decisions indexed
+     */
+    private int scanProject(Path projectRoot) throws Exception {
+        Path decisionsDir = projectRoot.resolve(".sdd/decisions");
+        if (!Files.exists(decisionsDir) || !Files.isDirectory(decisionsDir)) {
+            return 0;
+        }
+
+        int count = 0;
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(decisionsDir, "*.yaml")) {
+            for (Path yamlFile : stream) {
+                count += indexDecisionFile(yamlFile, projectRoot.toString());
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Parse a decision YAML file and index all decisions it contains.
+     *
+     * @param yamlFile    path to index.yaml or similar
+     * @param projectPath project root path string
+     * @return number of decisions indexed
+     */
+    @SuppressWarnings("unchecked")
+    private int indexDecisionFile(Path yamlFile, String projectPath) throws Exception {
+        String content = Files.readString(yamlFile);
+        Map<String, Object> root = yaml.load(content);
+
+        Object decisionsObj = root.get("decisions");
+        if (!(decisionsObj instanceof List)) {
+            LOG.warning("No 'decisions' array in " + yamlFile);
+            return 0;
+        }
+
+        List<Map<String, Object>> decisionsList = (List<Map<String, Object>>) decisionsObj;
+        int count = 0;
+
+        for (Map<String, Object> d : decisionsList) {
+            try {
+                Decision decision = parseDecision(d, projectPath);
+                store.upsert(decision);
+                count++;
+            } catch (Exception e) {
+                LOG.warning("Failed to parse decision in " + yamlFile + ": " + e.getMessage());
+            }
+        }
+
+        return count;
+    }
+
+    /**
+     * Parse a single decision map from YAML into a Decision record.
+     */
+    @SuppressWarnings("unchecked")
+    private Decision parseDecision(Map<String, Object> d, String projectPath) {
+        String id = (String) d.get("id");
+        String type = (String) d.get("type");
+        String domain = (String) d.get("domain");
+        String what = (String) d.get("what");
+        String why = (String) d.get("why");
+        String learned = (String) d.get("learned");
+        String updated = (String) d.get("updated");
+
+        List<String> alternatives = d.containsKey("alternatives")
+                ? (List<String>) d.get("alternatives")
+                : List.of();
+
+        List<String> tags = d.containsKey("tags")
+                ? (List<String>) d.get("tags")
+                : List.of();
+
+        return new Decision(id, type, domain, what, why, alternatives, learned, updated, tags, projectPath);
+    }
+
+    /**
+     * Simple scan result record.
+     */
+    public record ScanResult(int indexed, int skipped, int errorCount, List<String> errors) {
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/store/DecisionStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/DecisionStore.java
@@ -1,0 +1,190 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.Decision;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CRUD operations for the decisions table.
+ */
+public class DecisionStore {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Connection conn;
+
+    public DecisionStore(MemoryDatabase db) {
+        this.conn = db.getConnection();
+    }
+
+    /**
+     * Insert or update a decision (upsert by decision_id + project_path).
+     */
+    public void upsert(Decision d) throws SQLException {
+        String sql = """
+                INSERT INTO decisions
+                  (decision_id, type, domain, what, why, alternatives, learned, updated,
+                   tags, project_path, file_path, scanned_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,datetime('now'))
+                ON CONFLICT(decision_id, project_path) DO UPDATE SET
+                  type         = excluded.type,
+                  domain       = excluded.domain,
+                  what         = excluded.what,
+                  why          = excluded.why,
+                  alternatives = excluded.alternatives,
+                  learned      = excluded.learned,
+                  updated      = excluded.updated,
+                  tags         = excluded.tags,
+                  file_path    = excluded.file_path,
+                  scanned_at   = excluded.scanned_at
+                """;
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, d.id());
+            ps.setString(2, d.type());
+            ps.setString(3, d.domain());
+            ps.setString(4, d.what());
+            ps.setString(5, d.why());
+            ps.setString(6, toJson(d.alternatives()));
+            ps.setString(7, d.learned());
+            ps.setString(8, d.updated());
+            ps.setString(9, toJson(d.tags()));
+            ps.setString(10, d.projectPath());
+            ps.setString(11, d.projectPath() + "/.sdd/decisions/index.yaml");  // file_path
+            ps.executeUpdate();
+        }
+    }
+
+    /**
+     * Search decisions using FTS5 full-text search.
+     * Searches across what, why, tags, type, and domain fields.
+     *
+     * @param query FTS5 query string (e.g. "Lambda deployment", "video AND codec")
+     * @param limit max results
+     * @return list of matching decisions, ordered by relevance
+     */
+    public List<Decision> search(String query, int limit) throws SQLException {
+        String sql = """
+                SELECT d.decision_id, d.type, d.domain, d.what, d.why,
+                       d.alternatives, d.learned, d.updated, d.tags, d.project_path
+                FROM decisions_fts fts
+                JOIN decisions d ON fts.rowid = d.id
+                WHERE decisions_fts MATCH ?
+                ORDER BY rank
+                LIMIT ?
+                """;
+        List<Decision> results = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, query);
+            ps.setInt(2, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new Decision(
+                            rs.getString("decision_id"),
+                            rs.getString("type"),
+                            rs.getString("domain"),
+                            rs.getString("what"),
+                            rs.getString("why"),
+                            fromJsonList(rs.getString("alternatives")),
+                            rs.getString("learned"),
+                            rs.getString("updated"),
+                            fromJsonList(rs.getString("tags")),
+                            rs.getString("project_path")
+                    ));
+                }
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Filter decisions by type and/or domain.
+     *
+     * @param type   optional type filter (decision, anti-pattern, constraint, workaround)
+     * @param domain optional domain filter (deployment, testing, video-build, etc.)
+     * @param limit  max results
+     * @return list of matching decisions
+     */
+    public List<Decision> filter(String type, String domain, int limit) throws SQLException {
+        StringBuilder sql = new StringBuilder("SELECT decision_id, type, domain, what, why, " +
+                "alternatives, learned, updated, tags, project_path FROM decisions WHERE 1=1");
+        List<Object> params = new ArrayList<>();
+
+        if (type != null && !type.isBlank()) {
+            sql.append(" AND type = ?");
+            params.add(type);
+        }
+        if (domain != null && !domain.isBlank()) {
+            sql.append(" AND domain = ?");
+            params.add(domain);
+        }
+        sql.append(" ORDER BY scanned_at DESC LIMIT ?");
+        params.add(limit);
+
+        List<Decision> results = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            for (int i = 0; i < params.size(); i++) {
+                ps.setObject(i + 1, params.get(i));
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new Decision(
+                            rs.getString("decision_id"),
+                            rs.getString("type"),
+                            rs.getString("domain"),
+                            rs.getString("what"),
+                            rs.getString("why"),
+                            fromJsonList(rs.getString("alternatives")),
+                            rs.getString("learned"),
+                            rs.getString("updated"),
+                            fromJsonList(rs.getString("tags")),
+                            rs.getString("project_path")
+                    ));
+                }
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Get total count of indexed decisions.
+     */
+    public int count() throws SQLException {
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM decisions")) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    /**
+     * Delete all decisions from a specific project (used when rescanning).
+     */
+    public void deleteByProject(String projectPath) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement("DELETE FROM decisions WHERE project_path = ?")) {
+            ps.setString(1, projectPath);
+            ps.executeUpdate();
+        }
+    }
+
+    private String toJson(List<String> list) {
+        if (list == null || list.isEmpty()) return "[]";
+        try {
+            return MAPPER.writeValueAsString(list);
+        } catch (JsonProcessingException e) {
+            return "[]";
+        }
+    }
+
+    private List<String> fromJsonList(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            return MAPPER.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            return List.of();
+        }
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
@@ -76,7 +76,8 @@ public class MemoryDatabase implements AutoCloseable {
                 "/db/V5__manifest_version.sql",
                 "/db/V6__peer_sync.sql",
                 "/db/V7__pending_tasks.sql",
-                "/db/V8__memory_governance.sql"}) {
+                "/db/V8__memory_governance.sql",
+                "/db/V9__decisions.sql"}) {
 
             String version = resource.substring(resource.lastIndexOf('/') + 1, resource.lastIndexOf('.'));
 

--- a/java/src/main/resources/db/V9__decisions.sql
+++ b/java/src/main/resources/db/V9__decisions.sql
@@ -1,0 +1,54 @@
+-- kcp-memory v0.33.0 — Decision memory
+-- Indexes architectural decisions, constraints, and anti-patterns from project .sdd/decisions/*.yaml
+
+CREATE TABLE IF NOT EXISTS decisions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    decision_id     TEXT    NOT NULL,           -- kebab-case ID from YAML
+    type            TEXT    NOT NULL,           -- decision | anti-pattern | constraint | workaround
+    domain          TEXT    NOT NULL,           -- deployment | testing | video-build | etc.
+    what            TEXT    NOT NULL,           -- one-sentence summary
+    why             TEXT    NOT NULL,           -- reasoning/context
+    alternatives    TEXT,                       -- JSON array of rejected alternatives
+    learned         TEXT    NOT NULL,           -- session ID or skill reference
+    updated         TEXT,                       -- session ID if revised (optional)
+    tags            TEXT,                       -- JSON array of keywords
+    project_path    TEXT    NOT NULL,           -- which project this came from
+    file_path       TEXT    NOT NULL,           -- full path to source YAML file
+    scanned_at      TEXT    NOT NULL,           -- when kcp-memory indexed this
+    UNIQUE(decision_id, project_path)           -- same ID can exist in different projects
+);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_type ON decisions(type);
+CREATE INDEX IF NOT EXISTS idx_decisions_domain ON decisions(domain);
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project_path);
+
+-- FTS5 index over decision content for fast keyword search
+CREATE VIRTUAL TABLE IF NOT EXISTS decisions_fts USING fts5(
+    decision_id UNINDEXED,
+    type,
+    domain,
+    what,
+    why,
+    tags,
+    project_path UNINDEXED,
+    content='decisions',
+    content_rowid='id'
+);
+
+-- Keep FTS in sync with decisions table
+CREATE TRIGGER IF NOT EXISTS decisions_ai AFTER INSERT ON decisions BEGIN
+    INSERT INTO decisions_fts(rowid, decision_id, type, domain, what, why, tags, project_path)
+    VALUES (new.id, new.decision_id, new.type, new.domain, new.what, new.why, new.tags, new.project_path);
+END;
+
+CREATE TRIGGER IF NOT EXISTS decisions_au AFTER UPDATE ON decisions BEGIN
+    INSERT INTO decisions_fts(decisions_fts, rowid, decision_id, type, domain, what, why, tags, project_path)
+    VALUES ('delete', old.id, old.decision_id, old.type, old.domain, old.what, old.why, old.tags, old.project_path);
+    INSERT INTO decisions_fts(rowid, decision_id, type, domain, what, why, tags, project_path)
+    VALUES (new.id, new.decision_id, new.type, new.domain, new.what, new.why, new.tags, new.project_path);
+END;
+
+CREATE TRIGGER IF NOT EXISTS decisions_ad AFTER DELETE ON decisions BEGIN
+    INSERT INTO decisions_fts(decisions_fts, rowid, decision_id, type, domain, what, why, tags, project_path)
+    VALUES ('delete', old.id, old.decision_id, old.type, old.domain, old.what, old.why, old.tags, old.project_path);
+END;


### PR DESCRIPTION
Continues #36, which has been open since 21 May and went CONFLICTING as main moved from v0.32 to v0.35. `maintainerCanModify` is off on that PR, so this is a rebased continuation — **@StigLau's commit is cherry-picked with his authorship intact** (`stiglau <stig@lau.no>`).

## What the feature adds
`kcp_memory_decisions`: queries a decision-memory index — architectural decisions, constraints, anti-patterns — scanned from project `.sdd/decisions/*.yaml` files. +587 lines: `Decision` model, `DecisionScanner`, `DecisionStore`, migration, MCP tool wiring.

## What the rebase changed (and why)
- **Migration renumbered V8 → V9.** Main's v0.33 took `V8__memory_governance.sql`; both claimed V8. His schema is untouched, only the number moved.
- **Tool-list and switch conflicts resolved as unions** — `forget`/`retention` (main) and `decisions` (his) coexist.
- **"Added in v0.33.0" → "v0.36.0"** in the tool description — 0.33 shipped without it.
- **His second commit (version bump to 0.33.0) dropped** — stale; versioning belongs to the next release.

## Verified
`mvn test`: **144 tests, 0 failures** with the feature integrated.

Closes #36 when merged (superseding, with credit — thanks @StigLau, and apologies this sat ten weeks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)