### PR TITLE
feat: daemon process supervision, configurable port/db-path, peer provenance

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,13 +1,30 @@
 #!/usr/bin/env bash
 # kcp-memory installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/Cantara/kcp-memory/main/bin/install.sh | bash
+#
+# By default, installs process supervision (#32) so the daemon survives crashes
+# and reboots: a systemd --user unit on Linux, a launchd LaunchAgent on macOS.
+# Pass --no-supervision to opt back into the old session-scoped `nohup` behavior
+# instead — a curl|bash installer silently starting a service that persists
+# across logins is a bigger jump than the old behavior, and shouldn't surprise
+# someone who just wants to try the tool.
 
 set -euo pipefail
+
+NO_SUPERVISION=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-supervision) NO_SUPERVISION=true ;;
+    esac
+done
 
 KCP_DIR="${HOME}/.kcp"
 RELEASE_URL="https://github.com/Cantara/kcp-memory/releases/latest/download/kcp-memory-daemon.jar"
 HOOK_URL="https://raw.githubusercontent.com/Cantara/kcp-memory/main/bin/memory-hook.sh"
+SYSTEMD_UNIT_URL="https://raw.githubusercontent.com/Cantara/kcp-memory/main/bin/systemd/kcp-memory.service"
+LAUNCHD_PLIST_URL="https://raw.githubusercontent.com/Cantara/kcp-memory/main/bin/launchd/com.cantara.kcp-memory.plist"
 SETTINGS="${HOME}/.claude/settings.json"
+PORT="${KCP_MEMORY_PORT:-7735}"
 
 echo "[kcp-memory] installing..."
 
@@ -23,20 +40,73 @@ echo "[kcp-memory] downloading memory-hook.sh..."
 curl -fsSL -o "${KCP_DIR}/memory-hook.sh" "${HOOK_URL}"
 chmod +x "${KCP_DIR}/memory-hook.sh"
 
+install_nohup_fallback() {
+    pkill -f kcp-memory-daemon 2>/dev/null || true
+    nohup java -jar "${KCP_DIR}/kcp-memory-daemon.jar" daemon \
+        > /tmp/kcp-memory-daemon.log 2>&1 &
+}
+
+install_systemd() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        echo "[kcp-memory] systemctl not found — falling back to nohup"
+        install_nohup_fallback
+        return
+    fi
+    SYSTEMD_DIR="${HOME}/.config/systemd/user"
+    mkdir -p "${SYSTEMD_DIR}"
+    curl -fsSL -o "${SYSTEMD_DIR}/kcp-memory.service" "${SYSTEMD_UNIT_URL}"
+    systemctl --user daemon-reload
+    systemctl --user enable --now kcp-memory
+}
+
+install_launchd() {
+    PLIST_DIR="${HOME}/Library/LaunchAgents"
+    PLIST_PATH="${PLIST_DIR}/com.cantara.kcp-memory.plist"
+    mkdir -p "${PLIST_DIR}"
+    curl -fsSL -o "${PLIST_PATH}.tmpl" "${LAUNCHD_PLIST_URL}"
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "${PLIST_PATH}.tmpl" "${PLIST_PATH}" "${HOME}" <<'PYEOF'
+import plistlib, sys
+tmpl, out, home = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(tmpl, "rb") as f:
+    data = plistlib.load(f)
+data["ProgramArguments"] = [a.replace("__HOME__", home) for a in data["ProgramArguments"]]
+data["StandardOutPath"] = data["StandardOutPath"].replace("__HOME__", home)
+data["StandardErrorPath"] = data["StandardErrorPath"].replace("__HOME__", home)
+with open(out, "wb") as f:
+    plistlib.dump(data, f)
+PYEOF
+    else
+        sed "s|__HOME__|${HOME}|g" "${PLIST_PATH}.tmpl" > "${PLIST_PATH}"
+    fi
+    rm -f "${PLIST_PATH}.tmpl"
+    launchctl unload "${PLIST_PATH}" 2>/dev/null || true
+    launchctl load -w "${PLIST_PATH}"
+}
+
 # Start daemon
 echo "[kcp-memory] starting daemon..."
-pkill -f kcp-memory-daemon 2>/dev/null || true
-nohup java -jar "${KCP_DIR}/kcp-memory-daemon.jar" daemon \
-    > /tmp/kcp-memory-daemon.log 2>&1 &
+if [ "${NO_SUPERVISION}" = true ]; then
+    install_nohup_fallback
+else
+    case "$(uname -s)" in
+        Linux)  install_systemd ;;
+        Darwin) install_launchd ;;
+        *)
+            echo "[kcp-memory] unsupported OS for process supervision — falling back to nohup"
+            install_nohup_fallback
+            ;;
+    esac
+fi
 
 # Wait a moment for startup
 sleep 2
 
 # Verify
-if curl -sf --max-time 3 http://localhost:7735/health >/dev/null 2>&1; then
-    echo "[kcp-memory] daemon running on port 7735"
+if curl -sf --max-time 3 "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+    echo "[kcp-memory] daemon running on port ${PORT}"
 else
-    echo "[kcp-memory] warning: daemon may not have started — check /tmp/kcp-memory-daemon.log"
+    echo "[kcp-memory] warning: daemon may not have started — check ~/.kcp/daemon.log (or /tmp/kcp-memory-daemon.log with --no-supervision)"
 fi
 
 # Wire PostToolUse hook into ~/.claude/settings.json
@@ -76,6 +146,7 @@ echo ""
 echo "[kcp-memory] installation complete!"
 echo ""
 echo "Commands:"
+echo "  kcp-memory status                     # health, uptime, freshness, supervision state"
 echo "  kcp-memory scan                       # index sessions"
 echo "  kcp-memory search 'query'            # search session history"
 echo "  kcp-memory events search 'query'     # search tool-call events (requires kcp-commands v0.9.0)"

--- a/bin/launchd/com.cantara.kcp-memory.plist
+++ b/bin/launchd/com.cantara.kcp-memory.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cantara.kcp-memory</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>java</string>
+        <string>--enable-native-access=ALL-UNNAMED</string>
+        <string>-jar</string>
+        <string>__HOME__/.kcp/kcp-memory-daemon.jar</string>
+        <string>daemon</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/.kcp/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.kcp/daemon.log</string>
+</dict>
+</plist>

--- a/bin/systemd/kcp-memory.service
+++ b/bin/systemd/kcp-memory.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=kcp-memory daemon
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.kcp/kcp.env
+ExecStart=/usr/bin/env java --enable-native-access=ALL-UNNAMED -jar %h/.kcp/kcp-memory-daemon.jar daemon
+Restart=always
+RestartSec=5
+StandardOutput=append:%h/.kcp/daemon.log
+StandardError=append:%h/.kcp/daemon.log
+
+[Install]
+WantedBy=default.target

--- a/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
+++ b/java/src/main/java/com/cantara/kcp/memory/KcpMemoryDaemon.java
@@ -16,6 +16,7 @@ import com.cantara.kcp.memory.update.UpdateChecker;
 
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
- * HTTP daemon — listens on localhost:7735.
+ * HTTP daemon — listens on localhost, port {@link #DEFAULT_PORT} (7735) unless configured otherwise.
  *
  * <p>Uses a plain {@link TcpHttpServer} (ServerSocket + virtual threads) instead of
  * {@code com.sun.net.httpserver.HttpServer}, avoiding the NIO selector dependency
@@ -46,27 +47,38 @@ import java.util.logging.Logger;
 public class KcpMemoryDaemon {
 
     private static final Logger LOG = Logger.getLogger(KcpMemoryDaemon.class.getName());
-    public  static final int    PORT = 7735;
+    public  static final int    DEFAULT_PORT = 7735;
+    /** @deprecated use {@link #DEFAULT_PORT} — kept for source compatibility with embedders. */
+    @Deprecated
+    public  static final int    PORT = DEFAULT_PORT;
 
     private final MemoryDatabase db;
+    private final int port;
     private final NodeRegistry nodeRegistry = new NodeRegistry();
     private final EventBroadcaster broadcaster = new EventBroadcaster();
     private TcpHttpServer server;
     private ScheduledExecutorService scheduler;
     private final List<PeerSyncService> peerSyncServices = new ArrayList<>();
     private ExternalHttpServer externalServer;
+    private volatile Instant startTime;
 
     public KcpMemoryDaemon(MemoryDatabase db) {
+        this(db, DEFAULT_PORT);
+    }
+
+    public KcpMemoryDaemon(MemoryDatabase db, int port) {
         this.db = db;
+        this.port = port;
     }
 
     public void start() throws Exception {
-        server = new TcpHttpServer(PORT);
+        startTime = Instant.now();
+        server = new TcpHttpServer(port);
 
         IngestHandler ingestHandler = new IngestHandler(db);
         ingestHandler.setBroadcaster(broadcaster);
 
-        server.createContext("/health",        new HealthHandler(db));
+        server.createContext("/health",        new HealthHandler(db, startTime));
         server.createContext("/search",        new SearchHandler(db));
         server.createContext("/sessions",      new ListHandler(db));
         server.createContext("/stats",         new StatsHandler(db));
@@ -91,7 +103,7 @@ public class KcpMemoryDaemon {
         server.createContext("/pending", pendingHandler);
 
         server.start();
-        LOG.info("kcp-memory daemon started on port " + PORT);
+        LOG.info("kcp-memory daemon started on port " + port);
 
         // Startup update check — non-blocking, once per 24h
         Thread.ofVirtual().start(() -> {
@@ -164,7 +176,7 @@ public class KcpMemoryDaemon {
         externalServer = new ExternalHttpServer(bindAddress, port, tlsCert, tlsKey, apiKey);
 
         // Register all internal endpoints (same data, external auth)
-        externalServer.createContext("/health", new HealthHandler(db));
+        externalServer.createContext("/health", new HealthHandler(db, startTime));
         externalServer.createContext("/search", new SearchHandler(db));
         externalServer.createContext("/sessions", new ListHandler(db));
         externalServer.createContext("/stats", new StatsHandler(db));

--- a/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
+++ b/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
@@ -18,15 +18,23 @@ import com.cantara.kcp.memory.store.MemoryDatabase;
 import com.cantara.kcp.memory.store.SessionStore;
 import com.cantara.kcp.memory.store.ToolUsageStore;
 import com.cantara.kcp.memory.update.UpdateChecker;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
 import picocli.CommandLine.*;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * kcp-memory CLI — subcommands: daemon, scan, search, list, stats, analyze, events, agents, mcp
@@ -38,6 +46,7 @@ import java.util.concurrent.Callable;
         description = "Episodic memory for Claude Code — index and query session history",
         subcommands = {
                 KcpMemoryCli.DaemonCmd.class,
+                KcpMemoryCli.StatusCmd.class,
                 KcpMemoryCli.ScanCmd.class,
                 KcpMemoryCli.SearchCmd.class,
                 KcpMemoryCli.ListCmd.class,
@@ -58,13 +67,56 @@ public class KcpMemoryCli implements Callable<Integer> {
     }
 
     // ------------------------------------------------------------------
+    // shared options (#46) — reused across every subcommand that opens the
+    // DB or talks to the daemon, so they always agree on port/db-path with
+    // each other and with whatever KCP_MEMORY_PORT/KCP_MEMORY_DB is set to.
+    // ------------------------------------------------------------------
+    static class DbPathMixin {
+        @Option(names = "--db-path",
+                description = "Path to the kcp-memory SQLite database (default: ~/.kcp/memory.db, or KCP_MEMORY_DB env)",
+                defaultValue = "${KCP_MEMORY_DB}")
+        String dbPath;
+
+        MemoryDatabase open() throws java.sql.SQLException {
+            if (dbPath == null || dbPath.isBlank() || dbPath.equals("${KCP_MEMORY_DB}")) {
+                return new MemoryDatabase();
+            }
+            return new MemoryDatabase(Path.of(dbPath.replace("~", System.getProperty("user.home"))));
+        }
+    }
+
+    static class PortMixin {
+        @Option(names = "--port",
+                description = "Daemon HTTP port (default: 7735, or KCP_MEMORY_PORT env)",
+                defaultValue = "${KCP_MEMORY_PORT}")
+        String port;
+
+        int resolve() {
+            if (port == null || port.isBlank() || port.equals("${KCP_MEMORY_PORT}")) {
+                return KcpMemoryDaemon.DEFAULT_PORT;
+            }
+            try {
+                return Integer.parseInt(port.trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid --port value: " + port);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
     // daemon — start the HTTP daemon
     // ------------------------------------------------------------------
-    @Command(name = "daemon", description = "Start the kcp-memory HTTP daemon on port 7735")
+    @Command(name = "daemon", description = "Start the kcp-memory HTTP daemon")
     static class DaemonCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
+        @Mixin
+        PortMixin portOpt = new PortMixin();
+
         @Option(names = "--peer", arity = "0..*",
-                description = "Peer URI(s) for bidirectional sync (repeatable: ssh://user@host or tcp://host:port)")
+                description = "Peer URI(s) for bidirectional sync (repeatable: ssh://user@host[:sshport][?port=remoteHttpPort], or tcp://host:port)")
         private List<String> peerUris;
 
         @Option(names = "--serve",
@@ -96,11 +148,11 @@ public class KcpMemoryCli implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            MemoryDatabase db = new MemoryDatabase();
-            KcpMemoryDaemon daemon = new KcpMemoryDaemon(db);
+            int port = portOpt.resolve();
+            MemoryDatabase db = dbOpt.open();
+            KcpMemoryDaemon daemon = new KcpMemoryDaemon(db, port);
             daemon.start();
-            System.out.printf("[kcp-memory] daemon running on port %d — press Ctrl+C to stop%n",
-                    KcpMemoryDaemon.PORT);
+            System.out.printf("[kcp-memory] daemon running on port %d — press Ctrl+C to stop%n", port);
 
             // Start peer sync if --peer specified
             String localId = java.net.InetAddress.getLocalHost().getHostName();
@@ -119,13 +171,13 @@ public class KcpMemoryCli implements Callable<Integer> {
                 }
                 String[] parts = serveAddress.split(":");
                 String host = parts.length > 1 ? parts[0] : "0.0.0.0";
-                int port = Integer.parseInt(parts[parts.length - 1]);
+                int externalPort = Integer.parseInt(parts[parts.length - 1]);
 
                 // Expand ~ in capture-dir
                 String expandedCaptureDir = captureDir.replace("~", System.getProperty("user.home"));
 
-                daemon.startExternalServer(host, port, tlsCert, tlsKey, apiKey, expandedCaptureDir, synthesisCmd);
-                System.out.printf("[kcp-memory] external API serving on %s:%d%n", host, port);
+                daemon.startExternalServer(host, externalPort, tlsCert, tlsKey, apiKey, expandedCaptureDir, synthesisCmd);
+                System.out.printf("[kcp-memory] external API serving on %s:%d%n", host, externalPort);
             }
 
             Thread.currentThread().join(); // block until killed
@@ -134,10 +186,86 @@ public class KcpMemoryCli implements Callable<Integer> {
     }
 
     // ------------------------------------------------------------------
+    // status — health, uptime, freshness, process-supervision state (#32)
+    // ------------------------------------------------------------------
+    @Command(name = "status", description = "Show daemon health, uptime, freshness, and process-supervision state")
+    static class StatusCmd implements Callable<Integer> {
+
+        @Mixin
+        PortMixin portOpt = new PortMixin();
+
+        @Override
+        public Integer call() {
+            int port = portOpt.resolve();
+            JsonNode health = fetchHealth(port);
+            if (health == null) {
+                System.out.println("  daemon:      NOT RUNNING (or unreachable on port " + port + ")");
+                printSupervision();
+                return 1;
+            }
+            System.out.println("  daemon:      running");
+            System.out.printf("  version:     %s%n", health.path("version").asText("?"));
+            System.out.printf("  sessions:    %,d%n", health.path("sessions").asLong(0));
+            System.out.printf("  uptime:      %s%n", formatDuration(health.path("uptimeSeconds").asLong(-1)));
+            System.out.printf("  last scan:   %s (%s ago)%n",
+                    health.path("lastScannedAt").asText("never"),
+                    health.hasNonNull("freshnessSeconds") ? formatDuration(health.path("freshnessSeconds").asLong()) : "unknown");
+            printSupervision();
+            return 0;
+        }
+
+        private JsonNode fetchHealth(int port) {
+            try {
+                HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+                HttpRequest req = HttpRequest.newBuilder()
+                        .uri(URI.create("http://127.0.0.1:" + port + "/health"))
+                        .timeout(Duration.ofSeconds(2)).GET().build();
+                HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+                return resp.statusCode() == 200 ? new ObjectMapper().readTree(resp.body()) : null;
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private void printSupervision() {
+            String os = System.getProperty("os.name", "").toLowerCase();
+            if (os.contains("mac")) {
+                String out = runQuiet("launchctl", "list", "com.cantara.kcp-memory");
+                System.out.printf("  supervision: launchd — %s%n", out != null && !out.isBlank() ? "loaded" : "not loaded");
+            } else if (os.contains("linux")) {
+                String out = runQuiet("systemctl", "--user", "is-active", "kcp-memory");
+                System.out.printf("  supervision: systemd (--user) — %s%n", out != null ? out.trim() : "unknown (systemctl unavailable)");
+            } else {
+                System.out.println("  supervision: unmanaged (unsupported OS for auto-detection)");
+            }
+        }
+
+        private static String runQuiet(String... cmd) {
+            try {
+                Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+                String out = new String(p.getInputStream().readAllBytes());
+                p.waitFor(3, TimeUnit.SECONDS);
+                return out;
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private static String formatDuration(long s) {
+            if (s < 0) return "?";
+            long h = s / 3600, m = (s % 3600) / 60, sec = s % 60;
+            return h > 0 ? String.format("%dh%dm", h, m) : m > 0 ? String.format("%dm%ds", m, sec) : sec + "s";
+        }
+    }
+
+    // ------------------------------------------------------------------
     // scan — index session transcripts
     // ------------------------------------------------------------------
     @Command(name = "scan", description = "Scan ~/.claude/projects/ and index new/changed sessions")
     static class ScanCmd implements Callable<Integer> {
+
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
 
         @Option(names = {"--force", "-f"}, description = "Re-index all sessions, not just new ones")
         boolean force;
@@ -148,7 +276,7 @@ public class KcpMemoryCli implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            try (MemoryDatabase db = new MemoryDatabase()) {
+            try (MemoryDatabase db = dbOpt.open()) {
                 // Main session scan
                 SessionScanner scanner = new SessionScanner(db);
                 System.out.println("[kcp-memory] scanning sessions...");
@@ -182,6 +310,9 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "search", description = "Search session transcripts using full-text search")
     static class SearchCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
         @Parameters(arity = "1..*", description = "Search query")
         List<String> queryWords;
 
@@ -191,7 +322,7 @@ public class KcpMemoryCli implements Callable<Integer> {
         @Override
         public Integer call() throws Exception {
             String query = String.join(" ", queryWords);
-            try (MemoryDatabase db = new MemoryDatabase()) {
+            try (MemoryDatabase db = dbOpt.open()) {
                 SessionStore store = new SessionStore(db);
                 List<SearchResult> results = store.search(query, limit);
                 UsageLogger.logSearchSync(query, results.size());
@@ -214,6 +345,9 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "list", description = "List recent Claude Code sessions")
     static class ListCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
         @Option(names = {"--project", "-p"}, description = "Filter by project directory")
         String project;
 
@@ -222,7 +356,7 @@ public class KcpMemoryCli implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            try (MemoryDatabase db = new MemoryDatabase()) {
+            try (MemoryDatabase db = dbOpt.open()) {
                 SessionStore store = new SessionStore(db);
                 List<SearchResult> sessions = store.list(project, limit);
                 if (sessions.isEmpty()) {
@@ -246,9 +380,12 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "stats", description = "Show aggregate statistics across all indexed sessions")
     static class StatsCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
         @Override
         public Integer call() throws Exception {
-            try (MemoryDatabase db = new MemoryDatabase()) {
+            try (MemoryDatabase db = dbOpt.open()) {
                 SessionStore sessionStore = new SessionStore(db);
                 ToolUsageStore toolStore  = new ToolUsageStore(db);
                 AgentSessionStore agentStore = new AgentSessionStore(db);
@@ -288,6 +425,9 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "analyze", description = "Analyze manifest quality — surface manifests that correlate with retries, errors, and help lookups")
     static class AnalyzeCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
         @Option(names = {"--top"}, description = "Number of manifests to show (default: 20)", defaultValue = "20")
         int top;
 
@@ -302,7 +442,7 @@ public class KcpMemoryCli implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            try (MemoryDatabase db = new MemoryDatabase()) {
+            try (MemoryDatabase db = dbOpt.open()) {
                 // Ingest any new events before analyzing
                 new EventLogScanner(db).scan();
 
@@ -444,6 +584,9 @@ public class KcpMemoryCli implements Callable<Integer> {
         @Command(name = "search", description = "Full-text search over indexed tool-call events")
         static class EventsSearchCmd implements Callable<Integer> {
 
+            @Mixin
+            DbPathMixin dbOpt = new DbPathMixin();
+
             @Parameters(arity = "1..*", description = "Search query")
             List<String> queryWords;
 
@@ -453,7 +596,7 @@ public class KcpMemoryCli implements Callable<Integer> {
             @Override
             public Integer call() throws Exception {
                 String query = String.join(" ", queryWords);
-                try (MemoryDatabase db = new MemoryDatabase()) {
+                try (MemoryDatabase db = dbOpt.open()) {
                     // Ingest any new events before searching
                     new EventLogScanner(db).scan();
 
@@ -505,6 +648,9 @@ public class KcpMemoryCli implements Callable<Integer> {
         @Command(name = "list", description = "List subagent sessions, optionally filtered by parent session")
         static class AgentsListCmd implements Callable<Integer> {
 
+            @Mixin
+            DbPathMixin dbOpt = new DbPathMixin();
+
             @Option(names = {"--session", "-s"}, description = "Filter by parent session ID")
             String sessionId;
 
@@ -513,7 +659,7 @@ public class KcpMemoryCli implements Callable<Integer> {
 
             @Override
             public Integer call() throws Exception {
-                try (MemoryDatabase db = new MemoryDatabase()) {
+                try (MemoryDatabase db = dbOpt.open()) {
                     AgentSessionStore store = new AgentSessionStore(db);
                     List<AgentSession> agents;
                     if (sessionId != null && !sessionId.isBlank()) {
@@ -539,6 +685,9 @@ public class KcpMemoryCli implements Callable<Integer> {
         @Command(name = "search", description = "Search subagent transcripts using full-text search")
         static class AgentsSearchCmd implements Callable<Integer> {
 
+            @Mixin
+            DbPathMixin dbOpt = new DbPathMixin();
+
             @Parameters(arity = "1..*", description = "Search query")
             List<String> queryWords;
 
@@ -548,7 +697,7 @@ public class KcpMemoryCli implements Callable<Integer> {
             @Override
             public Integer call() throws Exception {
                 String query = String.join(" ", queryWords);
-                try (MemoryDatabase db = new MemoryDatabase()) {
+                try (MemoryDatabase db = dbOpt.open()) {
                     AgentSessionStore store = new AgentSessionStore(db);
                     List<AgentSession> results = store.search(query, limit);
                     if (results.isEmpty()) {
@@ -591,11 +740,14 @@ public class KcpMemoryCli implements Callable<Integer> {
     @Command(name = "mcp", description = "Start the kcp-memory MCP stdio server (for ~/.claude/settings.json mcpServers)")
     static class McpCmd implements Callable<Integer> {
 
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
         @Override
         public Integer call() throws Exception {
             // JUL ConsoleHandler already writes to System.err by default —
             // stdout is the MCP protocol channel and must not be polluted.
-            MemoryDatabase db = new MemoryDatabase();
+            MemoryDatabase db = dbOpt.open();
             new McpServer(db).run();
             db.close();
             return 0;

--- a/java/src/main/java/com/cantara/kcp/memory/handler/HealthHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/HealthHandler.java
@@ -6,17 +6,23 @@ import com.cantara.kcp.memory.server.TcpExchange;
 import com.cantara.kcp.memory.store.SessionStore;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * GET /health — liveness check with session count.
+ * GET /health — liveness check with session count, uptime, and scan freshness (#32).
  */
 public class HealthHandler extends BaseHandler {
 
     private final SessionStore sessionStore;
+    private final Instant startTime;
 
-    public HealthHandler(MemoryDatabase db) {
+    public HealthHandler(MemoryDatabase db, Instant startTime) {
         this.sessionStore = new SessionStore(db);
+        this.startTime = startTime;
     }
 
     @Override
@@ -27,13 +33,36 @@ public class HealthHandler extends BaseHandler {
         }
         try {
             SessionStore.Stats stats = sessionStore.stats();
-            sendJson(ex, 200, Map.of(
-                    "status", "ok",
-                    "sessions", stats.totalSessions(),
-                    "version", McpServer.SERVER_VERSION
-            ));
+            Instant lastScanned = parseFlexibleInstant(stats.lastScannedAt());
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("status", "ok");
+            body.put("sessions", stats.totalSessions());
+            body.put("version", McpServer.SERVER_VERSION);
+            body.put("uptimeSeconds", Duration.between(startTime, Instant.now()).getSeconds());
+            body.put("lastScannedAt", stats.lastScannedAt());
+            body.put("freshnessSeconds", lastScanned != null
+                    ? Duration.between(lastScanned, Instant.now()).getSeconds() : null);
+            sendJson(ex, 200, body);
         } catch (Exception e) {
             sendJson(ex, 200, Map.of("status", "degraded", "error", e.getMessage()));
+        }
+    }
+
+    /**
+     * scanned_at is written in two formats today — ISO-8601 ({@code Instant.toString()})
+     * by the scanners, SQLite {@code datetime('now')} (space-separated, no offset) by the
+     * ingest/pull paths. Tolerate both rather than fail the whole health check on one.
+     */
+    private static Instant parseFlexibleInstant(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return Instant.parse(raw);
+        } catch (DateTimeParseException e1) {
+            try {
+                return Instant.parse(raw.replace(' ', 'T') + "Z");
+            } catch (DateTimeParseException e2) {
+                return null;
+            }
         }
     }
 }

--- a/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
+++ b/java/src/main/java/com/cantara/kcp/memory/handler/IngestHandler.java
@@ -4,6 +4,7 @@ import com.cantara.kcp.memory.peer.PeerSyncService;
 import com.cantara.kcp.memory.server.EventBroadcaster;
 import com.cantara.kcp.memory.server.TcpExchange;
 import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.cantara.kcp.memory.store.ProvenanceFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -96,11 +97,16 @@ public class IngestHandler extends BaseHandler {
 
             if (sessionId == null || startedAt == null) continue;
 
+            // Every memory carries provenance (#47) — distinguishable from a locally
+            // scanned session so a multi-node setup can tell where a memory came from.
+            String provenance = ProvenanceFormat.peer(source, projectDir, sessionId);
+
+            int inserted;
             try (PreparedStatement ps = db.getConnection().prepareStatement("""
                     INSERT OR IGNORE INTO sessions
                         (session_id, project_dir, first_message, started_at,
-                         turn_count, tool_call_count, scanned_at, source_instance)
-                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+                         turn_count, tool_call_count, scanned_at, source_instance, provenance)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?, ?)
                     """)) {
                 ps.setString(1, sessionId);
                 ps.setString(2, projectDir);
@@ -109,7 +115,24 @@ public class IngestHandler extends BaseHandler {
                 ps.setInt(5, turnCount);
                 ps.setInt(6, toolCallCount);
                 ps.setString(7, source);
-                count += ps.executeUpdate();
+                ps.setString(8, provenance);
+                inserted = ps.executeUpdate();
+            }
+            count += inserted;
+
+            // INSERT OR IGNORE was a no-op for a pre-existing session_id — every other
+            // column deliberately stays untouched (matches today's behavior), but backfill
+            // provenance if it was never set, first-write-wins like SessionStore.upsert's
+            // COALESCE(sessions.provenance, excluded.provenance).
+            if (inserted == 0) {
+                try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                        UPDATE sessions SET provenance = ?
+                        WHERE session_id = ? AND (provenance IS NULL OR provenance = '')
+                        """)) {
+                    ps.setString(1, provenance);
+                    ps.setString(2, sessionId);
+                    ps.executeUpdate();
+                }
             }
         }
         LOG.fine("Ingested " + count + " sessions from peer push");

--- a/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/PeerSyncService.java
@@ -2,6 +2,7 @@ package com.cantara.kcp.memory.peer;
 
 import com.cantara.kcp.memory.store.MemoryDatabase;
 import com.cantara.kcp.memory.store.PeerCursorStore;
+import com.cantara.kcp.memory.store.ProvenanceFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -274,11 +275,16 @@ public class PeerSyncService {
 
             if (sessionId == null || startedAt == null) continue;
 
+            // Every memory carries provenance (#47) — same distinguishable format the
+            // /ingest/sessions push path uses, so pulled sessions aren't left null.
+            String provenance = ProvenanceFormat.peer(source, projectDir, sessionId);
+
+            int inserted;
             try (PreparedStatement ps = db.getConnection().prepareStatement("""
                     INSERT OR IGNORE INTO sessions
                         (session_id, project_dir, first_message, started_at,
-                         turn_count, tool_call_count, scanned_at, source_instance)
-                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+                         turn_count, tool_call_count, scanned_at, source_instance, provenance)
+                    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), ?, ?)
                     """)) {
                 ps.setString(1, sessionId);
                 ps.setString(2, projectDir);
@@ -287,7 +293,19 @@ public class PeerSyncService {
                 ps.setInt(5, turnCount);
                 ps.setInt(6, toolCallCount);
                 ps.setString(7, source);
-                ps.executeUpdate();
+                ps.setString(8, provenance);
+                inserted = ps.executeUpdate();
+            }
+
+            if (inserted == 0) {
+                try (PreparedStatement ps = db.getConnection().prepareStatement("""
+                        UPDATE sessions SET provenance = ?
+                        WHERE session_id = ? AND (provenance IS NULL OR provenance = '')
+                        """)) {
+                    ps.setString(1, provenance);
+                    ps.setString(2, sessionId);
+                    ps.executeUpdate();
+                }
             }
 
             latestTs = startedAt;

--- a/java/src/main/java/com/cantara/kcp/memory/peer/SshTunnel.java
+++ b/java/src/main/java/com/cantara/kcp/memory/peer/SshTunnel.java
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 /**
  * Manages an SSH tunnel to a remote kcp-memory instance.
  *
- * <p>Spawns {@code ssh -N -L <localPort>:127.0.0.1:7735 <user>@<host>}
+ * <p>Spawns {@code ssh -N -L <localPort>:127.0.0.1:<remotePort> <user>@<host>}
  * as a child process and monitors its lifecycle. Reconnects with exponential
  * backoff on failure.
  *
@@ -20,13 +20,15 @@ public class SshTunnel {
 
     private static final Logger LOG = Logger.getLogger(SshTunnel.class.getName());
 
-    private static final int REMOTE_PORT = 7735;
+    /** Remote kcp-memory port assumed when a peer URI doesn't specify one (#46). */
+    private static final int DEFAULT_REMOTE_PORT = 7735;
     private static final int INITIAL_BACKOFF_MS = 2_000;
     private static final int MAX_BACKOFF_MS = 60_000;
 
     private final String sshUser;
     private final String sshHost;
     private final int sshPort;
+    private final int remotePort;
     private final int localPort;
 
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -40,15 +42,29 @@ public class SshTunnel {
      * @param sshPort SSH port (typically 22)
      */
     public SshTunnel(String sshUser, String sshHost, int sshPort) {
+        this(sshUser, sshHost, sshPort, DEFAULT_REMOTE_PORT);
+    }
+
+    /**
+     * @param sshUser SSH username
+     * @param sshHost remote hostname or IP
+     * @param sshPort SSH port (typically 22)
+     * @param remotePort the remote kcp-memory daemon's HTTP port (#46)
+     */
+    public SshTunnel(String sshUser, String sshHost, int sshPort, int remotePort) {
         this.sshUser = sshUser;
         this.sshHost = sshHost;
         this.sshPort = sshPort;
+        this.remotePort = remotePort;
         this.localPort = findFreePort();
     }
 
     /**
      * Parse a peer URI into an SshTunnel.
-     * Supports: {@code ssh://user@host} and {@code ssh://user@host:port}
+     * Supports: {@code ssh://user@host}, {@code ssh://user@host:sshport}, and an
+     * optional {@code ?port=} query param naming the remote kcp-memory HTTP port
+     * (#46), e.g. {@code ssh://user@host:22?port=7799}. Fully backward-compatible —
+     * no URI in production use today carries a {@code ?}.
      *
      * @return SshTunnel instance, or null if URI is not an SSH URI
      */
@@ -56,6 +72,20 @@ public class SshTunnel {
         if (!uri.startsWith("ssh://")) return null;
 
         String remainder = uri.substring("ssh://".length());
+
+        int remotePort = DEFAULT_REMOTE_PORT;
+        int qIdx = remainder.indexOf('?');
+        if (qIdx >= 0) {
+            String query = remainder.substring(qIdx + 1);
+            remainder = remainder.substring(0, qIdx);
+            for (String param : query.split("&")) {
+                String[] kv = param.split("=", 2);
+                if (kv.length == 2 && kv[0].equals("port")) {
+                    remotePort = Integer.parseInt(kv[1]);
+                }
+            }
+        }
+
         String user, host;
         int port = 22;
 
@@ -72,7 +102,7 @@ public class SshTunnel {
             host = hostPart;
         }
 
-        return new SshTunnel(user, host, port);
+        return new SshTunnel(user, host, port, remotePort);
     }
 
     /** Start the tunnel. Non-blocking — spawns a watcher thread. */
@@ -96,7 +126,7 @@ public class SshTunnel {
         LOG.info("SSH tunnel stopped");
     }
 
-    /** The local port that forwards to remote :7735. */
+    /** The local port that forwards to the remote daemon's port. */
     public int getLocalPort() {
         return localPort;
     }
@@ -155,7 +185,7 @@ public class SshTunnel {
         // -o ExitOnForwardFailure=yes: exit if port forward fails
         ProcessBuilder pb = new ProcessBuilder(
                 "ssh", "-N",
-                "-L", localPort + ":127.0.0.1:" + REMOTE_PORT,
+                "-L", localPort + ":127.0.0.1:" + remotePort,
                 "-p", String.valueOf(sshPort),
                 "-o", "ServerAliveInterval=30",
                 "-o", "ServerAliveCountMax=3",

--- a/java/src/main/java/com/cantara/kcp/memory/store/ProvenanceFormat.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/ProvenanceFormat.java
@@ -1,0 +1,28 @@
+package com.cantara.kcp.memory.store;
+
+/**
+ * Provenance-string formats (#47). Deliberately distinguishable prefixes so a
+ * memory's origin — scanned locally vs. received via peer sync — stays greppable
+ * without needing a separate column.
+ */
+public final class ProvenanceFormat {
+
+    private ProvenanceFormat() {}
+
+    /** A session indexed by this instance's own local scan. */
+    public static String local(String slug, String projectDir, String sessionId) {
+        String origin = slug != null && !slug.isBlank() ? slug : (projectDir != null ? projectDir : "");
+        return "claude-code:" + origin + "#" + sessionId;
+    }
+
+    /**
+     * A session received from a peer, via push (/ingest/sessions) or pull.
+     * Omits slug — the peer wire payload doesn't carry it today — so this
+     * falls back to project_dir only, unlike {@link #local}.
+     */
+    public static String peer(String sourceInstance, String projectDir, String sessionId) {
+        String peer = sourceInstance != null && !sourceInstance.isBlank() ? sourceInstance : "unknown";
+        String origin = projectDir != null ? projectDir : "";
+        return "claude-code-peer:" + peer + ":" + origin + "#" + sessionId;
+    }
+}

--- a/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/SessionStore.java
@@ -74,10 +74,7 @@ public class SessionStore {
 
     /** Derive a provenance descriptor from a session's own origin. */
     private static String deriveProvenance(Session s) {
-        String origin = s.getSlug() != null && !s.getSlug().isBlank()
-                ? s.getSlug()
-                : (s.getProjectDir() != null ? s.getProjectDir() : "");
-        return "claude-code:" + origin + "#" + s.getSessionId();
+        return ProvenanceFormat.local(s.getSlug(), s.getProjectDir(), s.getSessionId());
     }
 
     /** Return full session detail by session_id, or null if not found. */
@@ -242,7 +239,8 @@ public class SessionStore {
                   SUM(turn_count)   AS total_turns,
                   SUM(tool_call_count) AS total_tool_calls,
                   MIN(started_at)   AS oldest,
-                  MAX(started_at)   AS newest
+                  MAX(started_at)   AS newest,
+                  MAX(scanned_at)   AS last_scanned_at
                 FROM sessions
                 """;
         try (Statement st = conn.createStatement();
@@ -253,10 +251,11 @@ public class SessionStore {
                         rs.getLong("total_turns"),
                         rs.getLong("total_tool_calls"),
                         rs.getString("oldest"),
-                        rs.getString("newest")
+                        rs.getString("newest"),
+                        rs.getString("last_scanned_at")
                 );
             }
-            return new Stats(0, 0, 0, null, null);
+            return new Stats(0, 0, 0, null, null, null);
         }
     }
 
@@ -472,6 +471,7 @@ public class SessionStore {
             long totalTurns,
             long totalToolCalls,
             String oldest,
-            String newest
+            String newest,
+            String lastScannedAt
     ) {}
 }

--- a/java/src/test/java/com/cantara/kcp/memory/handler/HealthHandlerTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/HealthHandlerTest.java
@@ -1,0 +1,106 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.model.Session;
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.cantara.kcp.memory.store.SessionStore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** #32: /health must report uptime and scan freshness, not just session count. */
+class HealthHandlerTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private Path tempDb;
+    private MemoryDatabase db;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb = Files.createTempFile("kcp-test-", ".db");
+        db = new MemoryDatabase(tempDb);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    private JsonNode getHealth(HealthHandler handler) throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            byte[][] responseHolder = new byte[1][];
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    out.write("GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                    responseHolder[0] = client.getInputStream().readAllBytes();
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+            clientThread.join(2000);
+
+            String response = new String(responseHolder[0], StandardCharsets.UTF_8);
+            String body = response.substring(response.indexOf("\r\n\r\n") + 4);
+            return JSON.readTree(body);
+        }
+    }
+
+    @Test
+    void reportsUptimeSinceStartTime() throws Exception {
+        Instant startTime = Instant.now().minusSeconds(90);
+        HealthHandler handler = new HealthHandler(db, startTime);
+
+        JsonNode health = getHealth(handler);
+        assertEquals("ok", health.get("status").asText());
+        long uptime = health.get("uptimeSeconds").asLong();
+        assertTrue(uptime >= 90, "expected uptime >= 90s, got " + uptime);
+    }
+
+    @Test
+    void reportsNullFreshnessWhenNoSessionsScanned() throws Exception {
+        HealthHandler handler = new HealthHandler(db, Instant.now());
+        JsonNode health = getHealth(handler);
+        assertTrue(health.get("lastScannedAt").isNull());
+        assertTrue(health.get("freshnessSeconds").isNull());
+    }
+
+    @Test
+    void reportsFreshnessFromMostRecentScan() throws Exception {
+        SessionStore store = new SessionStore(db);
+        Session s = new Session();
+        s.setSessionId("sess-health-001");
+        s.setProjectDir("/src/test");
+        s.setStartedAt(Instant.now().toString());
+        s.setScannedAt(Instant.now().minusSeconds(30).toString());
+        store.upsert(s);
+
+        HealthHandler handler = new HealthHandler(db, Instant.now());
+        JsonNode health = getHealth(handler);
+
+        assertFalse(health.get("lastScannedAt").isNull());
+        long freshness = health.get("freshnessSeconds").asLong();
+        assertTrue(freshness >= 30 && freshness < 60, "expected freshness ~30s, got " + freshness);
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/handler/IngestProvenanceTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/handler/IngestProvenanceTest.java
@@ -1,0 +1,135 @@
+package com.cantara.kcp.memory.handler;
+
+import com.cantara.kcp.memory.server.TcpExchange;
+import com.cantara.kcp.memory.store.MemoryDatabase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #47: POST /ingest/sessions must set a distinguishable provenance for
+ * peer-synced sessions, and must not clobber provenance already recorded.
+ */
+class IngestProvenanceTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private IngestHandler handler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb = Files.createTempFile("kcp-test-", ".db");
+        db = new MemoryDatabase(tempDb);
+        handler = new IngestHandler(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    private void postSessions(String payload) throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+
+            Thread clientThread = Thread.ofVirtual().start(() -> {
+                try (Socket client = new Socket("127.0.0.1", port)) {
+                    OutputStream out = client.getOutputStream();
+                    byte[] bodyBytes = payload.getBytes(StandardCharsets.UTF_8);
+                    String request = "POST /ingest/sessions HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Content-Type: application/json\r\n"
+                            + "Content-Length: " + bodyBytes.length + "\r\n"
+                            + "\r\n";
+                    out.write(request.getBytes(StandardCharsets.UTF_8));
+                    out.write(bodyBytes);
+                    out.flush();
+                    client.getInputStream().readAllBytes();
+                } catch (IOException ignored) {}
+            });
+
+            Socket serverSide = ss.accept();
+            try (TcpExchange ex = new TcpExchange(serverSide)) {
+                handler.handle(ex);
+            }
+            clientThread.join(2000);
+        }
+    }
+
+    private String provenanceOf(String sessionId) throws Exception {
+        try (PreparedStatement ps = db.getConnection().prepareStatement(
+                "SELECT provenance FROM sessions WHERE session_id = ?")) {
+            ps.setString(1, sessionId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getString("provenance") : null;
+            }
+        }
+    }
+
+    @Test
+    void peerPushSetsDistinguishableProvenance() throws Exception {
+        String payload = """
+                {
+                  "sessions": [
+                    {
+                      "session_id": "sess-peer-001",
+                      "project_dir": "/src/test",
+                      "first_message": "hello",
+                      "started_at": "2026-04-12T17:00:00Z",
+                      "turn_count": 3,
+                      "tool_call_count": 5,
+                      "source_instance": "laptop"
+                    }
+                  ]
+                }
+                """;
+        postSessions(payload);
+
+        String provenance = provenanceOf("sess-peer-001");
+        assertNotNull(provenance);
+        assertTrue(provenance.startsWith("claude-code-peer:"), "expected peer-prefixed provenance, got: " + provenance);
+        assertTrue(provenance.contains("laptop"), "expected source_instance in provenance, got: " + provenance);
+    }
+
+    @Test
+    void repushDoesNotClobberExistingProvenance() throws Exception {
+        String firstPush = """
+                {
+                  "sessions": [
+                    {
+                      "session_id": "sess-peer-002",
+                      "project_dir": "/src/test",
+                      "first_message": "hello",
+                      "started_at": "2026-04-12T17:00:00Z",
+                      "turn_count": 1,
+                      "tool_call_count": 1,
+                      "source_instance": "laptop"
+                    }
+                  ]
+                }
+                """;
+        postSessions(firstPush);
+        String firstProvenance = provenanceOf("sess-peer-002");
+        assertNotNull(firstProvenance);
+        assertTrue(firstProvenance.contains("laptop"));
+
+        String secondPush = firstPush.replace("laptop", "desktop");
+        postSessions(secondPush);
+        String secondProvenance = provenanceOf("sess-peer-002");
+
+        assertEquals(firstProvenance, secondProvenance, "first-write-wins — a re-push must not overwrite existing provenance");
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/peer/SshTunnelTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/peer/SshTunnelTest.java
@@ -1,0 +1,51 @@
+package com.cantara.kcp.memory.peer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * #46: SshTunnel.fromUri must stay backward-compatible with every
+ * ssh://user@host[:sshport] form already in production use, while accepting
+ * an optional ?port= for the remote kcp-memory HTTP port.
+ */
+class SshTunnelTest {
+
+    @Test
+    void parsesUserAndHostWithDefaultSshAndRemotePort() {
+        SshTunnel tunnel = SshTunnel.fromUri("ssh://totto@ironclaw0.example.com");
+        assertNotNull(tunnel);
+        assertEquals("totto@ironclaw0.example.com", tunnel.getPeerId());
+    }
+
+    @Test
+    void parsesExplicitSshPort() {
+        SshTunnel tunnel = SshTunnel.fromUri("ssh://totto@ironclaw0.example.com:2222");
+        assertNotNull(tunnel);
+        assertEquals("totto@ironclaw0.example.com", tunnel.getPeerId());
+    }
+
+    @Test
+    void parsesRemotePortQueryParamWithDefaultSshPort() {
+        SshTunnel tunnel = SshTunnel.fromUri("ssh://totto@laptop.local?port=7799");
+        assertNotNull(tunnel);
+        assertEquals("totto@laptop.local", tunnel.getPeerId());
+    }
+
+    @Test
+    void parsesBothSshPortAndRemotePortQueryParam() {
+        SshTunnel tunnel = SshTunnel.fromUri("ssh://totto@laptop.local:2222?port=7799");
+        assertNotNull(tunnel);
+        assertEquals("totto@laptop.local", tunnel.getPeerId());
+    }
+
+    @Test
+    void returnsNullForNonSshUri() {
+        assertNull(SshTunnel.fromUri("tcp://host:7735"));
+    }
+
+    @Test
+    void requiresUserInUri() {
+        assertThrows(IllegalArgumentException.class, () -> SshTunnel.fromUri("ssh://host-without-user"));
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/store/SessionStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/SessionStoreTest.java
@@ -150,6 +150,27 @@ class SessionStoreTest {
         assertEquals(19, stats.totalToolCalls());
     }
 
+    @Test
+    void statsReportsLastScannedAt() throws SQLException {
+        Session s1 = makeSession("sess-010", "/src/y", "First");
+        s1.setScannedAt("2026-04-01T10:00:00Z");
+        store.upsert(s1);
+
+        Session s2 = makeSession("sess-011", "/src/y", "Second");
+        s2.setScannedAt("2026-04-02T10:00:00Z");
+        store.upsert(s2);
+
+        SessionStore.Stats stats = store.stats();
+        assertEquals("2026-04-02T10:00:00Z", stats.lastScannedAt());
+    }
+
+    @Test
+    void statsReportsNullLastScannedAtWhenEmpty() throws SQLException {
+        SessionStore.Stats stats = store.stats();
+        assertEquals(0, stats.totalSessions());
+        assertNull(stats.lastScannedAt());
+    }
+
     private Session makeSession(String id, String projectDir, String firstMessage) {
         Session s = new Session();
         s.setSessionId(id);


### PR DESCRIPTION
Closes #32, #46, #47.

## #32 — no process supervision
- New `kcp-memory status` subcommand: uptime, session count, last-scan freshness, OS-appropriate supervision state (`systemctl --user`/`launchctl`).
- `/health` gains `uptimeSeconds`, `lastScannedAt`, `freshnessSeconds`.
- `install.sh` installs a systemd `--user` unit (Linux) or launchd LaunchAgent (macOS) by default — `Restart=always`/`KeepAlive=true`. `--no-supervision` opts back into the old `nohup` behavior, since silently starting a service that persists across reboots is a bigger jump than today's session-scoped daemon.
- **Not included**: the hook-side event spool/replay in `memory-hook.sh` — bigger design problem, deliberate follow-up issue.

## #46 — port/DB path hardcoded
- New `--port`/`KCP_MEMORY_PORT` and `--db-path`/`KCP_MEMORY_DB` options, shared via a picocli `@Mixin` across all 10 `MemoryDatabase` call sites so every subcommand agrees.
- `SshTunnel` also hardcoded the *peer's* remote port to 7735 — fixing only the local port would've left peer sync broken against a non-default instance. `ssh://` peer URIs now accept an optional `?port=` query param, backward-compatible with every URI in production use today.

## #47 — peer-synced sessions had `provenance: NULL`
- New `ProvenanceFormat.local`/`.peer` — distinguishable prefixes (`claude-code:` vs `claude-code-peer:`) so a memory's origin stays greppable.
- `PeerSyncService.pullSessions()` had the identical bug on the pull side (not just the HTTP `/ingest/sessions` push path) — fixed too, same root cause.
- First-write-wins on re-push, matching `SessionStore.upsert`'s existing `COALESCE` semantics; every other column's on-conflict behavior is unchanged.

## Test plan
- [x] `mvn test` — 157/157 passing (144 existing + 13 new)
- [x] Manual: two daemon instances on different `--port`/`--db-path` running simultaneously without collision, both reporting correct isolated `/health`
- [x] Manual: `kcp-memory status` against a running daemon and an unreachable one (correct exit codes)
- [x] `systemd-analyze verify` passes on the new unit
- [x] launchd plist template substitution verified via `plistlib` (the actual macOS `launchctl load`/`KeepAlive` behavior is **not** verified from this Linux environment — flagging for a manual check on real hardware before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)