### PR TITLE
chore(release): v0.36.0 — daemon supervision, configurable port/db-path, peer provenance

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cantara.kcp</groupId>
     <artifactId>kcp-memory</artifactId>
-    <version>0.35.0</version>
+    <version>0.36.0</version>
     <packaging>jar</packaging>
 
     <name>kcp-memory</name>

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -67,7 +67,7 @@ public class McpServer {
 
     private static final Logger LOG              = Logger.getLogger(McpServer.class.getName());
     private static final String PROTOCOL_VERSION = "2024-11-05";
-    public  static final String SERVER_VERSION   = "0.35.0";
+    public  static final String SERVER_VERSION   = "0.36.0";
 
     private final ObjectMapper   mapper = new ObjectMapper();
     private final MemoryDatabase db;


### PR DESCRIPTION
Minor: #60 adds a new \`kcp-memory status\` subcommand and new \`--port\`/\`--db-path\` options — new capability, not a fix.

java/pom.xml              0.35.0 -> 0.36.0
McpServer.SERVER_VERSION  0.35.0 -> 0.36.0

## Test plan
- [x] \`mvn test\` — 157/157 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)