### PR TITLE
fix: CLI --version now matches /health version

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
+++ b/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 @Command(
         name = "kcp-memory",
         mixinStandardHelpOptions = true,
-        version = "0.22.0",
+        version = McpServer.SERVER_VERSION,
         description = "Episodic memory for Claude Code — index and query session history",
         subcommands = {
                 KcpMemoryCli.DaemonCmd.class,


### PR DESCRIPTION
Fixes #63. `KcpMemoryCli`'s picocli `@Command` annotation had its own hardcoded version literal (`0.22.0`), separate from `McpServer.SERVER_VERSION` (`0.36.0`, used by `/health` and everywhere else in the codebase) — the two drifted apart since 0.22.0's release. One-line fix: reference the same constant instead of maintaining a second copy.