### PR TITLE
feat: kcp-memory suggest-skill — mine recurring command patterns

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
+++ b/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
@@ -4,6 +4,7 @@ import com.cantara.kcp.memory.KcpMemoryDaemon;
 import com.cantara.kcp.memory.mcp.McpServer;
 import com.cantara.kcp.memory.mcp.UsageLogger;
 import com.cantara.kcp.memory.model.AgentSession;
+import com.cantara.kcp.memory.model.CommandPattern;
 import com.cantara.kcp.memory.model.ManifestQualityRecord;
 import com.cantara.kcp.memory.model.ManifestVersionRecord;
 import com.cantara.kcp.memory.model.SearchResult;
@@ -15,6 +16,7 @@ import com.cantara.kcp.memory.store.AgentSessionStore;
 import com.cantara.kcp.memory.store.EventStore;
 import com.cantara.kcp.memory.store.ManifestQualityStore;
 import com.cantara.kcp.memory.store.MemoryDatabase;
+import com.cantara.kcp.memory.store.PatternStore;
 import com.cantara.kcp.memory.store.SessionStore;
 import com.cantara.kcp.memory.store.ToolUsageStore;
 import com.cantara.kcp.memory.update.UpdateChecker;
@@ -32,6 +34,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +55,7 @@ import java.util.concurrent.TimeUnit;
                 KcpMemoryCli.ListCmd.class,
                 KcpMemoryCli.StatsCmd.class,
                 KcpMemoryCli.AnalyzeCmd.class,
+                KcpMemoryCli.SuggestSkillCmd.class,
                 KcpMemoryCli.EventsCmd.class,
                 KcpMemoryCli.AgentsCmd.class,
                 KcpMemoryCli.McpCmd.class,
@@ -561,6 +565,139 @@ public class KcpMemoryCli implements Callable<Integer> {
             }
             System.out.println();
             return 0;
+        }
+
+        private static String truncate(String s, int max) {
+            if (s == null) return "?";
+            return s.length() <= max ? s : s.substring(0, max - 1) + "…";
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // suggest-skill — mine recurring command patterns as draft skill YAML
+    // ------------------------------------------------------------------
+    @Command(name = "suggest-skill",
+             description = "Mine recurring command patterns across sessions as draft skill YAML (#19)")
+    static class SuggestSkillCmd implements Callable<Integer> {
+
+        @Mixin
+        DbPathMixin dbOpt = new DbPathMixin();
+
+        @Option(names = {"--since"}, description = "Only consider events from the last N days (default: 30)", defaultValue = "30")
+        int sinceDays;
+
+        @Option(names = {"--min-occurrences"}, description = "Exclude patterns seen in fewer than N distinct sessions (default: 3)", defaultValue = "3")
+        int minSessions;
+
+        @Option(names = {"--limit"}, description = "Max candidate patterns to return (default: 20)", defaultValue = "20")
+        int limit;
+
+        @Option(names = {"--out"}, description = "Directory to write one <name>.yaml file per candidate into (default: print to stdout)")
+        String outDir;
+
+        @Override
+        public Integer call() throws Exception {
+            try (MemoryDatabase db = dbOpt.open()) {
+                // Ingest any new events before mining
+                new EventLogScanner(db).scan();
+
+                PatternStore store = new PatternStore(db);
+                List<CommandPattern> patterns = store.findRecurringCommands(sinceDays, minSessions, limit);
+
+                if (patterns.isEmpty()) {
+                    System.out.printf("[kcp-memory] no recurring command patterns in the last %d days " +
+                            "(min %d distinct sessions).%n", sinceDays, minSessions);
+                    return 0;
+                }
+
+                System.out.printf("[kcp-memory] %d candidate pattern(s) — last %d days, min %d sessions%n%n",
+                        patterns.size(), sinceDays, minSessions);
+
+                java.nio.file.Path outPath = null;
+                if (outDir != null && !outDir.isBlank()) {
+                    outPath = Path.of(outDir.replace("~", System.getProperty("user.home")));
+                    Files.createDirectories(outPath);
+                }
+
+                java.util.Set<String> usedNames = new java.util.HashSet<>();
+                for (CommandPattern p : patterns) {
+                    String name = uniqueSlug(p.command(), usedNames);
+                    String yaml = draftSkillYaml(name, p);
+
+                    if (outPath != null) {
+                        java.nio.file.Path file = outPath.resolve(name + ".yaml");
+                        Files.writeString(file, yaml);
+                        System.out.printf("  %-45s  %2dx across %d sessions  -> %s%n",
+                                truncate(p.command(), 45), p.occurrenceCount(), p.sessionCount(), file);
+                    } else {
+                        System.out.println(yaml);
+                    }
+                }
+
+                if (outPath == null) {
+                    System.out.println("Review each draft above, edit description/instructions, then commit as a skill.");
+                } else {
+                    System.out.println();
+                    System.out.println("Review each draft in " + outPath + ", edit description/instructions, then commit.");
+                }
+                return 0;
+            }
+        }
+
+        private String draftSkillYaml(String name, CommandPattern p) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("# Draft generated by kcp-memory suggest-skill\n");
+            sb.append(String.format("# Pattern: \"%s\" appeared %d time%s across %d session%s%n",
+                    truncate(p.command(), 60),
+                    p.occurrenceCount(), p.occurrenceCount() == 1 ? "" : "s",
+                    p.sessionCount(), p.sessionCount() == 1 ? "" : "s"));
+            sb.append("name: ").append(name).append('\n');
+            sb.append("description: \"TODO — recurring command pattern, seen ")
+              .append(p.occurrenceCount()).append(" times across ").append(p.sessionCount())
+              .append(" sessions. Describe when an agent should reach for this.\"\n");
+            sb.append("instructions: |\n");
+            sb.append("  TODO: explain when/why to use this pattern.\n");
+            sb.append("\n");
+            sb.append("  ```bash\n");
+            sb.append("  ").append(p.command()).append('\n');
+            sb.append("  ```\n");
+            sb.append('\n');
+            List<String> ids = p.sessionIds();
+            String shownIds = ids.size() <= 3
+                    ? String.join(", ", ids)
+                    : String.join(", ", ids.subList(0, 3)) + ", +" + (ids.size() - 3) + " more";
+            sb.append("  Seen in sessions: ").append(shownIds).append('\n');
+            sb.append("  First seen: ").append(p.firstSeen()).append("   Last seen: ").append(p.lastSeen()).append('\n');
+            return sb.toString();
+        }
+
+        /** Slugify a command into a skill name; disambiguate collisions with -2, -3, etc. */
+        private String uniqueSlug(String command, java.util.Set<String> used) {
+            String base = slugify(command);
+            String candidate = base;
+            int n = 2;
+            while (!used.add(candidate)) {
+                candidate = base + "-" + n++;
+            }
+            return candidate;
+        }
+
+        private String slugify(String command) {
+            List<String> significant = new ArrayList<>();
+            for (String token : command.trim().split("\\s+")) {
+                if (significant.size() >= 5) break;
+                if (token.matches("^[A-Za-z_][A-Za-z0-9_]*=.*")) continue; // skip FOO=bar env assignments
+                significant.add(token);
+            }
+            String joined = significant.isEmpty() ? command : String.join(" ", significant);
+            String slug = joined.toLowerCase()
+                    .replaceAll("[^a-z0-9]+", "-")
+                    .replaceAll("^-+|-+$", "");
+            if (slug.length() > 40) {
+                slug = slug.substring(0, 40).replaceAll("-+$", "");
+            }
+            if (slug.isBlank()) slug = "recurring-command";
+            return slug + "-pattern";
         }
 
         private static String truncate(String s, int max) {

--- a/java/src/main/java/com/cantara/kcp/memory/model/CommandPattern.java
+++ b/java/src/main/java/com/cantara/kcp/memory/model/CommandPattern.java
@@ -1,0 +1,17 @@
+package com.cantara.kcp.memory.model;
+
+import java.util.List;
+
+/**
+ * A recurring command pattern mined from tool_events — the same command appearing
+ * across multiple distinct sessions, a candidate for extraction into a reusable
+ * skill manifest via {@code kcp-memory suggest-skill}.
+ */
+public record CommandPattern(
+        String command,
+        int occurrenceCount,
+        int sessionCount,
+        List<String> sessionIds,
+        String firstSeen,
+        String lastSeen
+) {}

--- a/java/src/main/java/com/cantara/kcp/memory/store/PatternStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/PatternStore.java
@@ -1,0 +1,96 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.CommandPattern;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mines tool_events for recurring command patterns — the same command appearing
+ * identically across multiple distinct sessions — as candidates for
+ * {@code kcp-memory suggest-skill}. Deliberately narrow (exact command match, not
+ * LLM summarization): the goal is generate-then-human-review, not auto-authored skills.
+ */
+public class PatternStore {
+
+    private final MemoryDatabase db;
+
+    public PatternStore(MemoryDatabase db) {
+        this.db = db;
+    }
+
+    /**
+     * Find commands that recur identically across at least {@code minSessions} distinct
+     * sessions within the last {@code sinceDays} days.
+     *
+     * @param sinceDays   only consider events from the last N days
+     * @param minSessions exclude commands seen in fewer than this many distinct sessions
+     * @param limit       return at most this many patterns
+     * @return patterns ranked by session count (most-recurring first), then occurrence count
+     */
+    public List<CommandPattern> findRecurringCommands(int sinceDays, int minSessions, int limit) throws SQLException {
+        String cutoff = Instant.now().minus(sinceDays, ChronoUnit.DAYS).toString();
+        Connection conn = db.getConnection();
+
+        String sql = """
+                SELECT command,
+                       COUNT(*)                  AS occurrence_count,
+                       COUNT(DISTINCT session_id) AS session_count,
+                       MIN(event_ts)              AS first_seen,
+                       MAX(event_ts)              AS last_seen
+                FROM   tool_events
+                WHERE  event_ts >= ?
+                  AND  command IS NOT NULL
+                  AND  trim(command) != ''
+                GROUP  BY command
+                HAVING COUNT(DISTINCT session_id) >= ?
+                ORDER  BY session_count DESC, occurrence_count DESC, last_seen DESC
+                LIMIT  ?
+                """;
+
+        List<CommandPattern> patterns = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, cutoff);
+            ps.setInt(2, minSessions);
+            ps.setInt(3, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String command = rs.getString("command");
+                    patterns.add(new CommandPattern(
+                            command,
+                            rs.getInt("occurrence_count"),
+                            rs.getInt("session_count"),
+                            sessionIdsFor(conn, command, cutoff),
+                            rs.getString("first_seen"),
+                            rs.getString("last_seen")
+                    ));
+                }
+            }
+        }
+        return patterns;
+    }
+
+    private List<String> sessionIdsFor(Connection conn, String command, String cutoff) throws SQLException {
+        String sql = """
+                SELECT DISTINCT session_id
+                FROM   tool_events
+                WHERE  command = ? AND event_ts >= ?
+                ORDER  BY session_id
+                """;
+        List<String> ids = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, command);
+            ps.setString(2, cutoff);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) ids.add(rs.getString(1));
+            }
+        }
+        return ids;
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/store/PatternStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/PatternStoreTest.java
@@ -1,0 +1,137 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.CommandPattern;
+import com.cantara.kcp.memory.model.ToolEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PatternStoreTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private EventStore eventStore;
+    private PatternStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb     = Files.createTempFile("kcp-pattern-test-", ".db");
+        db         = new MemoryDatabase(tempDb);
+        eventStore = new EventStore(db);
+        store      = new PatternStore(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    @Test
+    void findsCommandRecurringAcrossEnoughSessions() throws SQLException {
+        insert("npm run lint -- --fix", "session-1");
+        insert("npm run lint -- --fix", "session-2");
+        insert("npm run lint -- --fix", "session-3");
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 20);
+
+        assertEquals(1, patterns.size());
+        CommandPattern p = patterns.get(0);
+        assertEquals("npm run lint -- --fix", p.command());
+        assertEquals(3, p.occurrenceCount());
+        assertEquals(3, p.sessionCount());
+        assertEquals(3, p.sessionIds().size());
+    }
+
+    @Test
+    void excludesCommandBelowMinSessionThreshold() throws SQLException {
+        // Same command, but only 2 distinct sessions — below the default min of 3
+        insert("git status --short", "session-1");
+        insert("git status --short", "session-1");
+        insert("git status --short", "session-2");
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 20);
+
+        assertTrue(patterns.isEmpty(), "single-session repeats and 2-session commands should not qualify at min-sessions=3");
+    }
+
+    @Test
+    void repeatedCallsWithinOneSessionDoNotCountAsMultipleSessions() throws SQLException {
+        for (int i = 0; i < 10; i++) {
+            insert("dotnet test --filter Category=Fast", "session-1");
+        }
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 20);
+
+        assertTrue(patterns.isEmpty(), "10 repeats in ONE session must not satisfy a 3-session threshold");
+    }
+
+    @Test
+    void distinctCommandsAreNotGroupedTogether() throws SQLException {
+        insert("dotnet test --filter Category=Fast", "session-1");
+        insert("dotnet test --filter Category=Fast", "session-2");
+        insert("dotnet test --filter Category=Fast", "session-3");
+        insert("dotnet build", "session-1");
+        insert("dotnet build", "session-2");
+        insert("dotnet build", "session-3");
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 20);
+
+        assertEquals(2, patterns.size());
+        List<String> commands = patterns.stream().map(CommandPattern::command).toList();
+        assertTrue(commands.contains("dotnet test --filter Category=Fast"));
+        assertTrue(commands.contains("dotnet build"));
+    }
+
+    @Test
+    void respectsLimit() throws SQLException {
+        for (int cmd = 0; cmd < 5; cmd++) {
+            for (int sess = 0; sess < 3; sess++) {
+                insert("cmd-" + cmd, "session-" + sess);
+            }
+        }
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 2);
+
+        assertEquals(2, patterns.size());
+    }
+
+    @Test
+    void eventsOutsideSinceDaysWindowAreExcluded() throws SQLException {
+        String old = Instant.now().minusSeconds(60L * 60 * 24 * 90).toString(); // 90 days ago
+        insert("old-command", "session-1", old);
+        insert("old-command", "session-2", old);
+        insert("old-command", "session-3", old);
+
+        List<CommandPattern> patterns = store.findRecurringCommands(30, 3, 20);
+
+        assertTrue(patterns.isEmpty(), "events older than --since window must not count toward the pattern");
+    }
+
+    private void insert(String command, String sessionId) throws SQLException {
+        insert(command, sessionId, Instant.now().toString());
+    }
+
+    private void insert(String command, String sessionId, String eventTs) throws SQLException {
+        eventStore.insert(new ToolEvent(
+                0,
+                eventTs,
+                sessionId,
+                "/src/test-project",
+                "Bash",
+                command,
+                null,
+                null,
+                null,
+                eventTs
+        ));
+    }
+}


### PR DESCRIPTION
Fixes #19.

Adds `kcp-memory suggest-skill [--since N] [--min-occurrences N] [--limit N] [--out <dir>]`: finds commands that appear identically across at least `--min-occurrences` distinct sessions in the last `--since` days, and emits a draft skill YAML per pattern (stdout, or one `<name>.yaml` file per pattern under `--out`).

Deliberately narrow scope, matching the issue's own framing: exact command-string recurrence across sessions only, no LLM summarization, no fuzzy matching. Output is a human-review starting point (templated TODOs for description/instructions) — generate → review → edit → commit, not an auto-authored skill.

New: `CommandPattern` (model), `PatternStore` (mines `tool_events` via `COUNT(DISTINCT session_id)` grouped by exact command), `SuggestSkillCmd` (CLI). `PatternStoreTest` covers the min-session threshold, same-session repeats not counting as multiple sessions, distinct commands not merging, `--limit`, and the `--since` window boundary.

Validated end-to-end against both synthetic data and this machine's real event history — output matched expected occurrence/session counts exactly, including right at the min-occurrences boundary (a 3-occurrence/3-session pattern correctly included).

Not in scope (noted in the original issue as separate future work): error-string + fix-command correlation, and file/directory co-access patterns — this covers the primary proposed command shape and output format.