### PR TITLE
feat: analyze --propose — evidence-backed manifest edit proposals

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
+++ b/java/src/main/java/com/cantara/kcp/memory/cli/KcpMemoryCli.java
@@ -5,6 +5,7 @@ import com.cantara.kcp.memory.mcp.McpServer;
 import com.cantara.kcp.memory.mcp.UsageLogger;
 import com.cantara.kcp.memory.model.AgentSession;
 import com.cantara.kcp.memory.model.CommandPattern;
+import com.cantara.kcp.memory.model.ManifestEditProposal;
 import com.cantara.kcp.memory.model.ManifestQualityRecord;
 import com.cantara.kcp.memory.model.ManifestVersionRecord;
 import com.cantara.kcp.memory.model.SearchResult;
@@ -14,6 +15,7 @@ import com.cantara.kcp.memory.scanner.EventLogScanner;
 import com.cantara.kcp.memory.scanner.SessionScanner;
 import com.cantara.kcp.memory.store.AgentSessionStore;
 import com.cantara.kcp.memory.store.EventStore;
+import com.cantara.kcp.memory.store.ManifestEditProposalStore;
 import com.cantara.kcp.memory.store.ManifestQualityStore;
 import com.cantara.kcp.memory.store.MemoryDatabase;
 import com.cantara.kcp.memory.store.PatternStore;
@@ -444,6 +446,18 @@ public class KcpMemoryCli implements Callable<Integer> {
         @Option(names = {"--by-version"}, description = "Group results by manifest version (content hash) to compare before/after improvements")
         boolean byVersion;
 
+        @Option(names = {"--propose"}, description = "Mine evidence-backed edit proposals instead of the summary table (#64) — inert output for human review, never an automatic edit")
+        boolean propose;
+
+        @Option(names = {"--propose-threshold"}, description = "Minimum quality score to propose a manifest for review (0-1, higher = worse; default: 0.15)", defaultValue = "0.15")
+        double proposeThreshold;
+
+        @Option(names = {"--propose-evidence"}, description = "Max session IDs to attach as evidence per proposal (default: 5)", defaultValue = "5")
+        int proposeEvidence;
+
+        @Option(names = {"--out"}, description = "With --propose: directory to write one <manifest-key>.yaml proposal file into (default: print to stdout)")
+        String outDir;
+
         @Override
         public Integer call() throws Exception {
             try (MemoryDatabase db = dbOpt.open()) {
@@ -453,6 +467,10 @@ public class KcpMemoryCli implements Callable<Integer> {
                 ManifestQualityStore store = new ManifestQualityStore(db);
                 int  totalManifests = store.countManifests();
                 long totalCalls     = store.countManifestCalls();
+
+                if (propose) {
+                    return callPropose(db);
+                }
 
                 if (byVersion) {
                     return callByVersion(store, totalManifests, totalCalls);
@@ -565,6 +583,74 @@ public class KcpMemoryCli implements Callable<Integer> {
             }
             System.out.println();
             return 0;
+        }
+
+        private int callPropose(MemoryDatabase db) throws Exception {
+            ManifestEditProposalStore proposalStore = new ManifestEditProposalStore(db);
+            List<ManifestEditProposal> proposals = proposalStore.proposeEdits(
+                    sinceDays, minCalls, proposeThreshold, proposeEvidence);
+
+            if (proposals.isEmpty()) {
+                System.out.printf("[kcp-memory] no manifests at or above quality score %.2f in the last %d days " +
+                        "(min %d calls).%n", proposeThreshold, sinceDays, minCalls);
+                return 0;
+            }
+
+            System.out.printf("[kcp-memory] %d evidence-backed proposal(s) — last %d days, score >= %.2f%n%n",
+                    proposals.size(), sinceDays, proposeThreshold);
+
+            java.nio.file.Path outPath = null;
+            if (outDir != null && !outDir.isBlank()) {
+                outPath = Path.of(outDir.replace("~", System.getProperty("user.home")));
+                Files.createDirectories(outPath);
+            }
+
+            for (ManifestEditProposal p : proposals) {
+                String yaml = proposalYaml(p);
+                if (outPath != null) {
+                    java.nio.file.Path file = outPath.resolve(p.manifestKey() + ".yaml");
+                    Files.writeString(file, yaml);
+                    System.out.printf("  %-25s  score=%.2f  %2d/%d sessions  -> %s%n",
+                            truncate(p.manifestKey(), 25), p.qualityScore(),
+                            p.affectedSessions(), p.totalSessions(), file);
+                } else {
+                    System.out.println(yaml);
+                }
+            }
+
+            if (outPath == null) {
+                System.out.println("Inert proposals — review each, edit the real skill/manifest YAML, and commit a new signed version.");
+            } else {
+                System.out.println();
+                System.out.println("Inert proposals in " + outPath + " — review each, edit the real skill/manifest YAML, and commit a new signed version.");
+            }
+            return 0;
+        }
+
+        private String proposalYaml(ManifestEditProposal p) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("# Draft edit proposal generated by kcp-memory analyze --propose (#64)\n");
+            sb.append(String.format("# Evidence: manifest \"%s\" showed %s in %d of %d sessions (last %d days)%n",
+                    p.manifestKey(), p.reason(), p.affectedSessions(), p.totalSessions(), sinceDays));
+            sb.append("manifest_key: ").append(p.manifestKey()).append('\n');
+            sb.append("proposal: |\n");
+            sb.append("  TODO: describe the specific change to make to this manifest/skill.\n");
+            sb.append("evidence:\n");
+            sb.append("  reason: \"").append(p.reason()).append("\"\n");
+            sb.append("  quality_score: ").append(String.format("%.2f", p.qualityScore())).append('\n');
+            sb.append("  total_calls: ").append(p.totalCalls()).append('\n');
+            sb.append("  total_sessions: ").append(p.totalSessions()).append('\n');
+            sb.append("  affected_sessions: ").append(p.affectedSessions()).append('\n');
+            sb.append("  retry_sessions: ").append(p.retrySessions()).append('\n');
+            sb.append("  help_sessions: ").append(p.helpSessions()).append('\n');
+            sb.append("  error_sessions: ").append(p.errorSessions()).append('\n');
+            sb.append("  sessions:\n");
+            for (String sid : p.evidenceSessionIds()) {
+                sb.append("    - ").append(sid).append('\n');
+            }
+            sb.append("generated_at: ").append(p.generatedAt()).append('\n');
+            sb.append("status: proposed  # never auto-applied — human review required, see knowledge-context-protocol#199\n");
+            return sb.toString();
         }
 
         private static String truncate(String s, int max) {

--- a/java/src/main/java/com/cantara/kcp/memory/model/ManifestEditProposal.java
+++ b/java/src/main/java/com/cantara/kcp/memory/model/ManifestEditProposal.java
@@ -1,0 +1,27 @@
+package com.cantara.kcp.memory.model;
+
+import java.util.List;
+
+/**
+ * An evidence-backed proposal to review a skill/manifest — mined from the same
+ * retry/help-followup/error signals {@link com.cantara.kcp.memory.store.ManifestQualityStore}
+ * already tracks, but with per-session evidence attached.
+ * <p>
+ * Deliberately inert: a candidate for human review, never an automatic edit.
+ * See kcp-memory#64 (this mining half) and knowledge-context-protocol#199
+ * (the review/versioning half — a human-accepted proposal becomes a new signed
+ * manifest version through KCP's existing versioning, same as any other change).
+ */
+public record ManifestEditProposal(
+        String manifestKey,
+        String reason,
+        double qualityScore,
+        int totalCalls,
+        int totalSessions,
+        int affectedSessions,
+        int retrySessions,
+        int helpSessions,
+        int errorSessions,
+        List<String> evidenceSessionIds,
+        String generatedAt
+) {}

--- a/java/src/main/java/com/cantara/kcp/memory/store/ManifestEditProposalStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/ManifestEditProposalStore.java
@@ -1,0 +1,256 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.ManifestEditProposal;
+import com.cantara.kcp.memory.model.ManifestQualityRecord;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mines {@link ManifestQualityStore}'s quality signals into evidence-backed edit
+ * proposals (kcp-memory#64) — structured, inert output for human review, not
+ * automatic edits. Extends the existing "needs attention" heuristic (already in
+ * AnalyzeCmd) with per-session evidence: how many DISTINCT sessions exhibited
+ * each issue, and which ones — the "corrected in N of the last M sessions" shape
+ * the issue asked for.
+ * <p>
+ * Performance note: the per-session retry/help counts are computed with ONE
+ * aggregate query across all manifest keys each (same shape and cost as
+ * {@link ManifestQualityStore}'s own retry/help/error SQL), not one query per
+ * candidate manifest. An earlier version did the latter and, against a hot
+ * non-skill key like {@code SUPPRESSED} (over half of all tool_events on a
+ * real instance), a single per-candidate self-join took minutes. Only the
+ * small per-candidate evidence-session-ID lookup still runs per manifest, and
+ * {@link #isNonSkillKey} keeps degenerate keys like {@code SUPPRESSED} and
+ * {@code FILTER:*} out of consideration entirely — they were never authored
+ * skills, so there is nothing to propose editing.
+ */
+public class ManifestEditProposalStore {
+
+    /**
+     * Shared with ManifestQualityStore's error-signal heuristic — kept identical intentionally.
+     * NOTE: single {@code %} here, not {@code %%} — this constant is substituted as a plain
+     * *value* into another template's {@code %s} (see usages below), never itself passed
+     * through {@code .formatted()} as the template string. {@code String.formatted} does not
+     * recursively reprocess substituted argument text, so a doubled {@code %%} here would
+     * survive into the final SQL literally as two percent signs and never match anything.
+     */
+    private static final String ERROR_SIGNAL_CLAUSE = """
+            output_preview IS NOT NULL
+            AND (
+                LOWER(output_preview) LIKE 'error%'
+                OR LOWER(output_preview) LIKE '%exception%'
+                OR LOWER(output_preview) LIKE '%traceback%'
+                OR LOWER(output_preview) LIKE '%failed%'
+                OR LOWER(output_preview) LIKE '%command not found%'
+                OR LOWER(output_preview) LIKE '%no such file%'
+                OR LOWER(output_preview) LIKE '%exit code %'
+                OR LOWER(output_preview) LIKE '%exited with%'
+            )
+            """;
+
+    /** Same single-% note as {@link #ERROR_SIGNAL_CLAUSE} — substituted as a value, not a template. */
+    private static final String HELP_FOLLOWUP_JOIN_CLAUSE = """
+            e2.id > e1.id
+            AND (e2.command LIKE '%--help%' OR e2.command LIKE '% -h %' OR e2.command LIKE '% -h')
+            AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 300
+            """;
+
+    /**
+     * Excludes {@link #isNonSkillKey} keys at the SQL level, not just from the final
+     * Java-side candidate list. This matters a lot in practice: on a real instance,
+     * {@code SUPPRESSED} alone was over half of all tool_events (74k of 134k rows),
+     * and a retry self-join over just that one key took ~29 minutes. Filtering only
+     * the *output* of an aggregate query that still scans those rows to compute it
+     * doesn't help — the exclusion has to be in the WHERE clause so the planner can
+     * use the manifest_key index to skip the rows entirely.
+     */
+    private static final String NON_SKILL_KEY_EXCLUSION = "manifest_key != 'SUPPRESSED' AND manifest_key NOT LIKE 'FILTER:%'";
+    private static final String NON_SKILL_KEY_EXCLUSION_E1 = "e1.manifest_key != 'SUPPRESSED' AND e1.manifest_key NOT LIKE 'FILTER:%'";
+
+    private final MemoryDatabase db;
+    private final ManifestQualityStore qualityStore;
+
+    public ManifestEditProposalStore(MemoryDatabase db) {
+        this.db = db;
+        this.qualityStore = new ManifestQualityStore(db);
+    }
+
+    /**
+     * @param sinceDays      only consider events from the last N days
+     * @param minCalls       exclude manifests with fewer than this many calls
+     * @param scoreThreshold only propose manifests at or above this composite quality score
+     *                       (same 0-1 scale as ManifestQualityStore, higher = worse)
+     * @param evidenceLimit  max session IDs to attach as evidence per proposal
+     * @return proposals ranked worst quality first
+     */
+    public List<ManifestEditProposal> proposeEdits(int sinceDays, int minCalls, double scoreThreshold, int evidenceLimit) throws SQLException {
+        List<ManifestQualityRecord> candidates = qualityStore.analyze(sinceDays, minCalls, Integer.MAX_VALUE)
+                .stream()
+                .filter(r -> r.qualityScore() >= scoreThreshold)
+                .filter(r -> !isNonSkillKey(r.manifestKey()))
+                .toList();
+
+        if (candidates.isEmpty()) return List.of();
+
+        Connection conn = db.getConnection();
+        String cutoff = sinceDays > 0
+                ? "datetime('now', '-" + sinceDays + " days')"
+                : "'1970-01-01T00:00:00Z'";
+        String now = Instant.now().toString();
+
+        // One aggregate pass per signal across ALL manifest keys — see class javadoc.
+        Map<String, Integer> totalSessionsByKey = distinctSessionCounts(conn, cutoff);
+        Map<String, Integer> retrySessionsByKey = distinctRetrySessionCounts(conn, cutoff);
+        Map<String, Integer> helpSessionsByKey  = distinctHelpSessionCounts(conn, cutoff);
+        Map<String, Integer> errorSessionsByKey = distinctErrorSessionCounts(conn, cutoff);
+
+        List<ManifestEditProposal> proposals = new ArrayList<>();
+        for (ManifestQualityRecord r : candidates) {
+            String key = r.manifestKey();
+            int totalSessions = totalSessionsByKey.getOrDefault(key, 0);
+            int retrySessions = retrySessionsByKey.getOrDefault(key, 0);
+            int helpSessions  = helpSessionsByKey.getOrDefault(key, 0);
+            int errorSessions = errorSessionsByKey.getOrDefault(key, 0);
+
+            String reason;
+            int affected;
+            String evidenceKind;
+            if (retrySessions >= helpSessions && retrySessions >= errorSessions) {
+                reason = "high retry rate (%.0f%% of calls)".formatted(r.retryRate() * 100);
+                affected = retrySessions;
+                evidenceKind = "retry";
+            } else if (helpSessions >= errorSessions) {
+                reason = "high --help follow-up rate (%.0f%% of calls)".formatted(r.helpFollowupRate() * 100);
+                affected = helpSessions;
+                evidenceKind = "help";
+            } else {
+                reason = "high error rate (%.0f%% of calls)".formatted(r.errorRate() * 100);
+                affected = errorSessions;
+                evidenceKind = "error";
+            }
+
+            // Only the small, per-candidate evidence-session-ID lookup runs per manifest —
+            // candidates are already filtered to non-degenerate keys with modest call counts.
+            List<String> evidence = evidenceSessionIds(conn, key, cutoff, evidenceKind, evidenceLimit);
+
+            proposals.add(new ManifestEditProposal(
+                    key, reason, r.qualityScore(),
+                    r.totalCalls(), totalSessions, affected,
+                    retrySessions, helpSessions, errorSessions,
+                    evidence, now
+            ));
+        }
+
+        proposals.sort((a, b) -> Double.compare(b.qualityScore(), a.qualityScore()));
+        return proposals;
+    }
+
+    /**
+     * Non-authored manifest keys with no skill/manifest YAML behind them — filter noise
+     * and suppressed-command markers, not candidates for a human to review or edit.
+     */
+    private static boolean isNonSkillKey(String manifestKey) {
+        return manifestKey == null
+                || "SUPPRESSED".equals(manifestKey)
+                || manifestKey.startsWith("FILTER:");
+    }
+
+    private Map<String, Integer> distinctSessionCounts(Connection conn, String cutoff) throws SQLException {
+        String sql = """
+                SELECT manifest_key, COUNT(DISTINCT session_id) AS n
+                FROM tool_events
+                WHERE manifest_key IS NOT NULL AND event_ts >= %s AND %s
+                GROUP BY manifest_key
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION);
+        return queryCountMap(conn, sql, "manifest_key");
+    }
+
+    private Map<String, Integer> distinctRetrySessionCounts(Connection conn, String cutoff) throws SQLException {
+        String sql = """
+                SELECT e1.manifest_key AS mk, COUNT(DISTINCT e1.session_id) AS n
+                FROM tool_events e1
+                JOIN tool_events e2 ON e1.manifest_key = e2.manifest_key
+                    AND e1.session_id = e2.session_id AND e2.id > e1.id
+                    AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 90
+                WHERE e1.manifest_key IS NOT NULL AND e1.event_ts >= %s AND %s
+                GROUP BY e1.manifest_key
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION_E1);
+        return queryCountMap(conn, sql, "mk");
+    }
+
+    private Map<String, Integer> distinctHelpSessionCounts(Connection conn, String cutoff) throws SQLException {
+        String sql = """
+                SELECT e1.manifest_key AS mk, COUNT(DISTINCT e1.session_id) AS n
+                FROM tool_events e1
+                JOIN tool_events e2 ON e1.session_id = e2.session_id AND %s
+                WHERE e1.manifest_key IS NOT NULL AND e1.event_ts >= %s AND %s
+                GROUP BY e1.manifest_key
+                """.formatted(HELP_FOLLOWUP_JOIN_CLAUSE, cutoff, NON_SKILL_KEY_EXCLUSION_E1);
+        return queryCountMap(conn, sql, "mk");
+    }
+
+    private Map<String, Integer> distinctErrorSessionCounts(Connection conn, String cutoff) throws SQLException {
+        String sql = """
+                SELECT manifest_key, COUNT(DISTINCT session_id) AS n
+                FROM tool_events
+                WHERE manifest_key IS NOT NULL AND event_ts >= %s AND %s AND %s
+                GROUP BY manifest_key
+                """.formatted(cutoff, ERROR_SIGNAL_CLAUSE, NON_SKILL_KEY_EXCLUSION);
+        return queryCountMap(conn, sql, "manifest_key");
+    }
+
+    private Map<String, Integer> queryCountMap(Connection conn, String sql, String keyColumn) throws SQLException {
+        Map<String, Integer> map = new LinkedHashMap<>();
+        try (Statement st = conn.createStatement();
+             ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                map.put(rs.getString(keyColumn), rs.getInt("n"));
+            }
+        }
+        return map;
+    }
+
+    private List<String> evidenceSessionIds(Connection conn, String manifestKey, String cutoff, String kind, int limit) throws SQLException {
+        String sql = switch (kind) {
+            case "retry" -> """
+                    SELECT e1.session_id AS sid, MAX(e1.event_ts) AS ts
+                    FROM tool_events e1
+                    JOIN tool_events e2 ON e1.manifest_key = e2.manifest_key
+                        AND e1.session_id = e2.session_id AND e2.id > e1.id
+                        AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 90
+                    WHERE e1.manifest_key = ? AND e1.event_ts >= %s
+                    GROUP BY e1.session_id ORDER BY ts DESC LIMIT ?
+                    """.formatted(cutoff);
+            case "help" -> """
+                    SELECT e1.session_id AS sid, MAX(e1.event_ts) AS ts
+                    FROM tool_events e1
+                    JOIN tool_events e2 ON e1.session_id = e2.session_id AND %s
+                    WHERE e1.manifest_key = ? AND e1.event_ts >= %s
+                    GROUP BY e1.session_id ORDER BY ts DESC LIMIT ?
+                    """.formatted(HELP_FOLLOWUP_JOIN_CLAUSE, cutoff);
+            default -> """
+                    SELECT session_id AS sid, MAX(event_ts) AS ts FROM tool_events
+                    WHERE manifest_key = ? AND event_ts >= %s AND %s
+                    GROUP BY session_id ORDER BY ts DESC LIMIT ?
+                    """.formatted(cutoff, ERROR_SIGNAL_CLAUSE);
+        };
+        List<String> ids = new ArrayList<>();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, manifestKey);
+            ps.setInt(2, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) ids.add(rs.getString("sid"));
+            }
+        }
+        return ids;
+    }
+}

--- a/java/src/test/java/com/cantara/kcp/memory/store/ManifestEditProposalStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/ManifestEditProposalStoreTest.java
@@ -1,0 +1,169 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.ManifestEditProposal;
+import com.cantara.kcp.memory.model.ToolEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManifestEditProposalStoreTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private EventStore eventStore;
+    private ManifestEditProposalStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb     = Files.createTempFile("kcp-proposal-test-", ".db");
+        db         = new MemoryDatabase(tempDb);
+        eventStore = new EventStore(db);
+        store      = new ManifestEditProposalStore(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    @Test
+    void proposesManifestWithHighRetryRateAndAttachesEvidence() throws SQLException {
+        // 3 sessions, each: call the manifest, then retry it within 90s — 100% retry rate
+        for (int i = 1; i <= 3; i++) {
+            String session = "session-" + i;
+            Instant t0 = Instant.now();
+            insert("dotnet-test", session, t0, null);
+            insert("dotnet-test", session, t0.plusSeconds(10), null);
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.15, 5);
+
+        assertEquals(1, proposals.size());
+        ManifestEditProposal p = proposals.get(0);
+        assertEquals("dotnet-test", p.manifestKey());
+        assertTrue(p.reason().contains("retry"), "expected retry to be the dominant reason: " + p.reason());
+        assertEquals(3, p.totalSessions());
+        assertEquals(3, p.affectedSessions());
+        assertEquals(3, p.retrySessions());
+        assertEquals(3, p.evidenceSessionIds().size());
+    }
+
+    @Test
+    void excludesManifestBelowScoreThreshold() throws SQLException {
+        // Single clean call per session, no retries/errors/help — quality score 0
+        for (int i = 1; i <= 5; i++) {
+            insert("clean-manifest", "session-" + i, Instant.now(), null);
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.15, 5);
+
+        assertTrue(proposals.isEmpty());
+    }
+
+    @Test
+    void excludesManifestBelowMinCalls() throws SQLException {
+        Instant t0 = Instant.now();
+        insert("rare-manifest", "session-1", t0, null);
+        insert("rare-manifest", "session-1", t0.plusSeconds(5), null);
+
+        // min-calls=5 excludes it even though its retry rate would otherwise qualify
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 5, 0.15, 5);
+
+        assertTrue(proposals.isEmpty());
+    }
+
+    @Test
+    void errorSignalDominatesReasonWhenHighestSignal() throws SQLException {
+        for (int i = 1; i <= 3; i++) {
+            insert("flaky-manifest", "session-" + i, Instant.now(), "Error: something exploded");
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.15, 5);
+
+        assertEquals(1, proposals.size());
+        assertTrue(proposals.get(0).reason().contains("error"), "expected error to dominate: " + proposals.get(0).reason());
+        assertEquals(3, proposals.get(0).errorSessions());
+    }
+
+    @Test
+    void excludesNonSkillKeysEvenWhenQualityScoreWouldQualify() throws SQLException {
+        // SUPPRESSED and FILTER:* are kcp-commands markers, not authored skills —
+        // never proposal candidates regardless of how bad their signals look.
+        for (int i = 1; i <= 3; i++) {
+            insert("SUPPRESSED", "session-" + i, Instant.now(), "Error: nope");
+        }
+        for (int i = 1; i <= 3; i++) {
+            insert("FILTER:grep", "session-" + i, Instant.now(), "Error: nope");
+        }
+        // A real, otherwise-identical manifest key should still be proposed.
+        for (int i = 1; i <= 3; i++) {
+            insert("real-skill", "session-" + i, Instant.now(), "Error: nope");
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.15, 5);
+
+        assertEquals(1, proposals.size());
+        assertEquals("real-skill", proposals.get(0).manifestKey());
+    }
+
+    @Test
+    void proposalsSortedWorstQualityFirst() throws SQLException {
+        // "mild" — 1 of 3 sessions retries
+        insert("mild-manifest", "session-1", Instant.now(), null);
+        Instant t0 = Instant.now();
+        insert("mild-manifest", "session-2", t0, null);
+        insert("mild-manifest", "session-2", t0.plusSeconds(5), null);
+        insert("mild-manifest", "session-3", Instant.now(), null);
+
+        // "severe" — all 3 sessions retry
+        for (int i = 1; i <= 3; i++) {
+            String session = "severe-session-" + i;
+            Instant t1 = Instant.now();
+            insert("severe-manifest", session, t1, null);
+            insert("severe-manifest", session, t1.plusSeconds(5), null);
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.05, 5);
+
+        assertTrue(proposals.size() >= 2);
+        assertEquals("severe-manifest", proposals.get(0).manifestKey());
+        assertTrue(proposals.get(0).qualityScore() >= proposals.get(1).qualityScore());
+    }
+
+    @Test
+    void evidenceRespectsLimit() throws SQLException {
+        for (int i = 1; i <= 8; i++) {
+            insert("busy-manifest", "session-" + i, Instant.now(), "Error: nope");
+        }
+
+        List<ManifestEditProposal> proposals = store.proposeEdits(30, 1, 0.15, 3);
+
+        assertEquals(1, proposals.size());
+        assertEquals(3, proposals.get(0).evidenceSessionIds().size());
+        assertEquals(8, proposals.get(0).errorSessions(), "the underlying count should reflect all 8, only evidence is capped");
+    }
+
+    private void insert(String manifestKey, String sessionId, Instant ts, String outputPreview) throws SQLException {
+        String iso = ts.toString();
+        String command = "some-command --for " + manifestKey;
+        eventStore.insert(new ToolEvent(
+                0, iso, sessionId, "/src/test-project", "Bash",
+                command, manifestKey, outputPreview, null, iso
+        ));
+        // EventStore.insert() never persists output_preview — matches production, where the
+        // command event is written first and output is attached separately (PostToolUse hook
+        // -> EventStore.updateOutputPreview) once the tool call actually completes.
+        if (outputPreview != null) {
+            eventStore.updateOutputPreview(sessionId, command, outputPreview);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #64.

Extends `kcp-memory analyze` with `--propose [--propose-threshold N] [--propose-evidence N] [--out <dir>]`: mines the same retry/help-followup/error signals `ManifestQualityStore` already tracks into structured, inert proposal YAML for human review, never an automatic edit. "Manifest X showed high retry rate in N of M sessions" plus specific session-ID evidence — the "corrected in N of the last M sessions" shape the issue asked for. See knowledge-context-protocol#199 for the companion review/versioning half.

New: `ManifestEditProposal` (model), `ManifestEditProposalStore` (mines `tool_events`), `AnalyzeCmd.callPropose`/`proposalYaml` (CLI). Output mirrors `suggest-skill`'s UX: stdout by default, or `--out <dir>` for one `<manifest-key>.yaml` file per proposal.

**Performance, found while validating against a real ~530MB/134k-row instance:** an earlier version computed retry/help/error session counts with one self-join query per candidate manifest. Against a hot non-skill key like `SUPPRESSED` (74k of 134k rows on that instance — a kcp-commands marker, not an authored skill), a single such self-join took ~29 minutes. Reworked to:
- one aggregate query per signal across all manifest keys (same shape `ManifestQualityStore`'s own retry/help/error SQL already uses), not one query per candidate
- exclude `SUPPRESSED`/`FILTER:*` at the SQL `WHERE`-clause level, not just from the final candidate list — filtering only the *output* of a query that still scanned those rows doesn't help; the exclusion has to let the planner skip the rows via the `manifest_key` index in the first place

`ManifestEditProposalStoreTest` covers: retry/help/error dominance selection, score threshold, min-calls, evidence limit, sort order, and the `SUPPRESSED`/`FILTER:*` exclusion holding even when their score would otherwise qualify.

Related, filed separately (pre-existing, not introduced by this PR): #67 (WAL growing unbounded on the long-running daemon) and a follow-up busy_timeout issue for CLI-vs-daemon lock contention.