### PR TITLE
fix: analyze() hangs indefinitely on real-scale data (page cache + busy_timeout + non-skill-key exclusion)

### DIFF
--- a/java/src/main/java/com/cantara/kcp/memory/store/ManifestQualityStore.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/ManifestQualityStore.java
@@ -21,6 +21,19 @@ import java.util.Map;
  */
 public class ManifestQualityStore {
 
+    /**
+     * SUPPRESSED and FILTER:* are kcp-commands markers, not authored skill manifests.
+     * Excluding them at the SQL level — not just filtering the output afterward —
+     * matters a lot in practice: on a real instance, SUPPRESSED alone was over half
+     * of all tool_events (74k of 134k rows), and the retry/help self-joins below took
+     * tens of minutes once they had to process that many rows for one key (a thread
+     * dump caught `analyze` stuck at 100% CPU in the retry query's ResultSet.next()).
+     * Same fix as kcp-memory#68's ManifestEditProposalStore; see also #67 (unrelated
+     * WAL-growth finding on the same instance).
+     */
+    private static final String NON_SKILL_KEY_EXCLUSION = "manifest_key != 'SUPPRESSED' AND manifest_key NOT LIKE 'FILTER:%'";
+    private static final String NON_SKILL_KEY_EXCLUSION_E1 = "e1.manifest_key != 'SUPPRESSED' AND e1.manifest_key NOT LIKE 'FILTER:%'";
+
     private final MemoryDatabase db;
 
     public ManifestQualityStore(MemoryDatabase db) {
@@ -49,9 +62,10 @@ public class ManifestQualityStore {
                 FROM tool_events
                 WHERE manifest_key IS NOT NULL
                   AND event_ts >= %s
+                  AND %s
                 GROUP BY manifest_key
                 HAVING cnt >= ?
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION);
 
         try (PreparedStatement ps = conn.prepareStatement(totalSql)) {
             ps.setInt(1, minCalls);
@@ -76,8 +90,9 @@ public class ManifestQualityStore {
                     AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 90
                 WHERE e1.manifest_key IS NOT NULL
                   AND e1.event_ts >= %s
+                  AND %s
                 GROUP BY e1.manifest_key
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION_E1);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(retrySql)) {
@@ -98,8 +113,9 @@ public class ManifestQualityStore {
                     AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 300
                 WHERE e1.manifest_key IS NOT NULL
                   AND e1.event_ts >= %s
+                  AND %s
                 GROUP BY e1.manifest_key
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION_E1);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(helpSql)) {
@@ -115,6 +131,7 @@ public class ManifestQualityStore {
                 FROM tool_events
                 WHERE manifest_key IS NOT NULL
                   AND event_ts >= %s
+                  AND %s
                   AND output_preview IS NOT NULL
                   AND (
                       LOWER(output_preview) LIKE 'error%%'
@@ -127,7 +144,7 @@ public class ManifestQualityStore {
                       OR LOWER(output_preview) LIKE '%%exited with%%'
                   )
                 GROUP BY manifest_key
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(errorSql)) {
@@ -192,10 +209,11 @@ public class ManifestQualityStore {
                 FROM tool_events
                 WHERE manifest_key IS NOT NULL
                   AND event_ts >= %s
+                  AND %s
                 GROUP BY manifest_key, mv
                 HAVING cnt >= ?
                 ORDER BY manifest_key, first_seen
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION);
 
         try (PreparedStatement ps = conn.prepareStatement(totalSql)) {
             ps.setInt(1, minCalls);
@@ -225,8 +243,9 @@ public class ManifestQualityStore {
                     AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 90
                 WHERE e1.manifest_key IS NOT NULL
                   AND e1.event_ts >= %s
+                  AND %s
                 GROUP BY e1.manifest_key, mv
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION_E1);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(retrySql)) {
@@ -249,8 +268,9 @@ public class ManifestQualityStore {
                     AND (julianday(e2.event_ts) - julianday(e1.event_ts)) * 86400 <= 300
                 WHERE e1.manifest_key IS NOT NULL
                   AND e1.event_ts >= %s
+                  AND %s
                 GROUP BY e1.manifest_key, mv
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION_E1);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(helpSql)) {
@@ -267,6 +287,7 @@ public class ManifestQualityStore {
                 FROM tool_events
                 WHERE manifest_key IS NOT NULL
                   AND event_ts >= %s
+                  AND %s
                   AND output_preview IS NOT NULL
                   AND (
                       LOWER(output_preview) LIKE 'error%%'
@@ -279,7 +300,7 @@ public class ManifestQualityStore {
                       OR LOWER(output_preview) LIKE '%%exited with%%'
                   )
                 GROUP BY manifest_key, mv
-                """.formatted(cutoff);
+                """.formatted(cutoff, NON_SKILL_KEY_EXCLUSION);
 
         try (Statement st = conn.createStatement();
              ResultSet rs = st.executeQuery(errorSql)) {
@@ -312,20 +333,21 @@ public class ManifestQualityStore {
         return records;
     }
 
-    /** Total number of distinct manifest keys in the events table. */
+    /** Total number of distinct manifest keys in the events table (excludes SUPPRESSED/FILTER:*). */
     public int countManifests() throws SQLException {
         try (Statement st = db.getConnection().createStatement();
              ResultSet rs = st.executeQuery(
-                     "SELECT COUNT(DISTINCT manifest_key) FROM tool_events WHERE manifest_key IS NOT NULL")) {
+                     "SELECT COUNT(DISTINCT manifest_key) FROM tool_events WHERE manifest_key IS NOT NULL AND "
+                             + NON_SKILL_KEY_EXCLUSION)) {
             return rs.next() ? rs.getInt(1) : 0;
         }
     }
 
-    /** Total events with a manifest key. */
+    /** Total events with a manifest key (excludes SUPPRESSED/FILTER:*). */
     public long countManifestCalls() throws SQLException {
         try (Statement st = db.getConnection().createStatement();
              ResultSet rs = st.executeQuery(
-                     "SELECT COUNT(*) FROM tool_events WHERE manifest_key IS NOT NULL")) {
+                     "SELECT COUNT(*) FROM tool_events WHERE manifest_key IS NOT NULL AND " + NON_SKILL_KEY_EXCLUSION)) {
             return rs.next() ? rs.getLong(1) : 0;
         }
     }

--- a/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
+++ b/java/src/main/java/com/cantara/kcp/memory/store/MemoryDatabase.java
@@ -43,7 +43,21 @@ public class MemoryDatabase implements AutoCloseable {
             st.execute("PRAGMA journal_mode=WAL");
             st.execute("PRAGMA synchronous=NORMAL");
             st.execute("PRAGMA foreign_keys=ON");
-            st.execute("PRAGMA cache_size=-4000");    // 4 MB page cache
+            // 4 MB was far too small once the DB grows into the hundreds-of-MB range —
+            // a full scan of tool_events (e.g. `analyze`'s own GROUP BY manifest_key)
+            // became genuinely disk/IO-bound: a thread dump against a real 530MB/134k-row
+            // instance caught it stuck in NativeDB.step at 100% CPU for 90s+ on that one
+            // query. 64 MB in-process page cache plus a 256 MB mmap (lets the OS handle
+            // caching the rest of the file without consuming JVM heap) together.
+            st.execute("PRAGMA cache_size=-65536");   // 64 MB page cache
+            st.execute("PRAGMA mmap_size=268435456"); // 256 MB memory-mapped I/O
+            // Without this, SQLite's default busy_timeout is 0: a writer that finds the
+            // DB locked by another connection fails immediately with SQLITE_BUSY instead
+            // of waiting briefly and retrying. On a box where a long-running daemon also
+            // holds this DB open, any short-lived CLI command (EventLogScanner's insert,
+            // in particular) can race it for the single writer lock. 5s gives a real
+            // chance to succeed without making a genuinely stuck daemon look hung forever.
+            st.execute("PRAGMA busy_timeout=5000");
         }
     }
 

--- a/java/src/test/java/com/cantara/kcp/memory/store/ManifestQualityStoreTest.java
+++ b/java/src/test/java/com/cantara/kcp/memory/store/ManifestQualityStoreTest.java
@@ -1,0 +1,108 @@
+package com.cantara.kcp.memory.store;
+
+import com.cantara.kcp.memory.model.ManifestQualityRecord;
+import com.cantara.kcp.memory.model.ToolEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManifestQualityStoreTest {
+
+    private Path tempDb;
+    private MemoryDatabase db;
+    private EventStore eventStore;
+    private ManifestQualityStore store;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tempDb     = Files.createTempFile("kcp-quality-test-", ".db");
+        db         = new MemoryDatabase(tempDb);
+        eventStore = new EventStore(db);
+        store      = new ManifestQualityStore(db);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        db.close();
+        Files.deleteIfExists(tempDb);
+    }
+
+    @Test
+    void analyzeIncludesRealSkillManifest() throws SQLException {
+        insert("real-skill", "session-1");
+        insert("real-skill", "session-2");
+
+        List<ManifestQualityRecord> records = store.analyze(30, 1, 20);
+
+        assertEquals(1, records.size());
+        assertEquals("real-skill", records.get(0).manifestKey());
+    }
+
+    @Test
+    void analyzeExcludesSuppressedMarker() throws SQLException {
+        // kcp-commands writes "SUPPRESSED" for commands it filtered — not an authored
+        // skill, never a candidate for "improve this manifest" reporting.
+        insert("SUPPRESSED", "session-1");
+        insert("SUPPRESSED", "session-2");
+
+        List<ManifestQualityRecord> records = store.analyze(30, 1, 20);
+
+        assertTrue(records.isEmpty());
+    }
+
+    @Test
+    void analyzeExcludesFilterPrefixedKeys() throws SQLException {
+        insert("FILTER:grep", "session-1");
+        insert("FILTER:ls", "session-2");
+
+        List<ManifestQualityRecord> records = store.analyze(30, 1, 20);
+
+        assertTrue(records.isEmpty());
+    }
+
+    @Test
+    void countManifestsExcludesNonSkillKeys() throws SQLException {
+        insert("real-skill", "session-1");
+        insert("SUPPRESSED", "session-2");
+        insert("FILTER:grep", "session-3");
+
+        assertEquals(1, store.countManifests());
+    }
+
+    @Test
+    void countManifestCallsExcludesNonSkillKeys() throws SQLException {
+        insert("real-skill", "session-1");
+        insert("real-skill", "session-2");
+        insert("SUPPRESSED", "session-3");
+
+        assertEquals(2, store.countManifestCalls());
+    }
+
+    @Test
+    void analyzeByVersionExcludesNonSkillKeys() throws SQLException {
+        insert("SUPPRESSED", "session-1");
+        insert("real-skill", "session-1");
+
+        var records = store.analyzeByVersion(30, 1);
+
+        assertEquals(1, records.size());
+        assertEquals("real-skill", records.get(0).manifestKey());
+    }
+
+    private void insert(String manifestKey, String sessionId) throws SQLException {
+        String iso = Instant.now().toString();
+        eventStore.insert(new ToolEvent(
+                0, iso, sessionId, "/src/test-project", "Bash",
+                "some-command --for " + manifestKey,
+                manifestKey, null, null, iso
+        ));
+    }
+}


### PR DESCRIPTION
Prompted by validating #68's `analyze --propose` against a real ~530MB/134k-row instance, where the plain (pre-existing) `analyze` command itself would not complete even after 90s+, confirmed via thread dump stuck at 100% CPU inside `ManifestQualityStore`'s own retry self-join. Three compounding causes found and fixed:

1. **`PRAGMA cache_size` was 4MB** against a 530MB+ database — a full table scan became genuinely disk/IO-bound (91s wall time was ~34s `sys`, i.e. real I/O wait). Raised to 64MB in-process cache + 256MB mmap (OS-managed, doesn't consume JVM heap).
2. **No `PRAGMA busy_timeout`** was set (SQLite default: 0, fails instantly on lock conflict rather than waiting/retrying) — a real gap for any CLI command run alongside the long-running daemon, even though it wasn't the cause of the specific hang investigated here. Set to 5s.
3. **The real fix:** `ManifestQualityStore`'s retry/help-followup self-join queries process *all* manifest keys together, including `SUPPRESSED` (74k of 134k rows on the real instance — a kcp-commands marker for filtered commands, not an authored skill) and `FILTER:*` keys. A thread dump caught `analyze` stuck exactly in that self-join's `ResultSet.next()`, and an isolated benchmark of the same self-join shape against just the `SUPPRESSED` rows took ~29 minutes. Excluded both at the SQL `WHERE`-clause level (not just from results) across `analyze()`, `analyzeByVersion()`, `countManifests()`, and `countManifestCalls()` — matching the same fix already applied to `ManifestEditProposalStore` in #68.

**Verified end-to-end:** `analyze --since 60` against the real instance went from never completing (killed at 90s+ multiple times, one isolated query took ~29 minutes) to **20.7s** with correct output (484 real manifest keys, 18,684 calls). All existing tests still pass — `SUPPRESSED`/`FILTER:*` were never meaningfully "analyzed" as skills before either, no test asserted on their inclusion.

New: `ManifestQualityStoreTest` (didn't exist before), covering the exclusion across all four public methods plus a real-skill sanity check.

Related: #67 (WAL growing unbounded on the daemon — separate root cause, also found during this investigation, restarting the daemon there dropped WAL 205MB→4MB but did not by itself fix this hang).