### PR TITLE
chore(release): v0.37.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cantara.kcp</groupId>
     <artifactId>kcp-memory</artifactId>
-    <version>0.36.0</version>
+    <version>0.37.0</version>
     <packaging>jar</packaging>
 
     <name>kcp-memory</name>

--- a/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
+++ b/java/src/main/java/com/cantara/kcp/memory/mcp/McpServer.java
@@ -67,7 +67,7 @@ public class McpServer {
 
     private static final Logger LOG              = Logger.getLogger(McpServer.class.getName());
     private static final String PROTOCOL_VERSION = "2024-11-05";
-    public  static final String SERVER_VERSION   = "0.36.0";
+    public  static final String SERVER_VERSION   = "0.37.0";
 
     private final ObjectMapper   mapper = new ObjectMapper();
     private final MemoryDatabase db;


### PR DESCRIPTION
## Summary
- Version bump 0.36.0 → 0.37.0 in `pom.xml` and `McpServer.SERVER_VERSION`, in lockstep (same pattern as #61).
- Covers work merged since v0.36.0: #63 (version-reporting fix), #19/#66 (suggest-skill), #64/#68 (propose-edits), #69 (SQLite performance fix — analyze() no longer hangs on real-scale data).

## Test plan
- [x] `mvn -q compile` passes
- [ ] Merge → tag `v0.37.0` → confirm `.github/workflows/release.yml` builds the jar and publishes the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)